### PR TITLE
[WIP] Replaced softmax with sparsemax in attention normalization

### DIFF
--- a/bert4keras/backend.py
+++ b/bert4keras/backend.py
@@ -12,50 +12,44 @@ from tensorflow.python.eager import tape
 from tensorflow.python.ops.custom_gradient import _graph_mode_decorator
 
 # 判断是tf.keras还是纯keras的标记
-is_tf_keras = strtobool(os.environ.get('TF_KERAS', '0'))
+is_tf_keras = strtobool(os.environ.get("TF_KERAS", "0"))
 
 if is_tf_keras:
-    sys.modules['keras'] = tf.keras
+    sys.modules["keras"] = tf.keras
 
 import keras
 import keras.backend as K
 
 # 判断是否启用重计算（通过时间换空间）
-do_recompute = strtobool(os.environ.get('RECOMPUTE', '0'))
+do_recompute = strtobool(os.environ.get("RECOMPUTE", "0"))
 
 
 def get_available_gpus():
-    """获取可用的GPU列表
-    """
+    """获取可用的GPU列表"""
     devices = device_lib.list_local_devices()
-    devices = [x.name for x in devices if x.device_type == 'GPU']
+    devices = [x.name for x in devices if x.device_type == "GPU"]
     return devices
 
 
 def gelu_erf(x):
-    """基于Erf直接计算的gelu函数
-    """
+    """基于Erf直接计算的gelu函数"""
     return 0.5 * x * (1.0 + tf.math.erf(x / np.sqrt(2.0)))
 
 
 def gelu_tanh(x):
-    """基于Tanh近似计算的gelu函数
-    """
-    cdf = 0.5 * (
-        1.0 + K.tanh((np.sqrt(2 / np.pi) * (x + 0.044715 * K.pow(x, 3))))
-    )
+    """基于Tanh近似计算的gelu函数"""
+    cdf = 0.5 * (1.0 + K.tanh((np.sqrt(2 / np.pi) * (x + 0.044715 * K.pow(x, 3)))))
     return x * cdf
 
 
 def set_gelu(version):
-    """设置gelu版本
-    """
+    """设置gelu版本"""
     version = version.lower()
-    assert version in ['erf', 'tanh'], 'gelu version must be erf or tanh'
-    if version == 'erf':
-        keras.utils.get_custom_objects()['gelu'] = gelu_erf
+    assert version in ["erf", "tanh"], "gelu version must be erf or tanh"
+    if version == "erf":
+        keras.utils.get_custom_objects()["gelu"] = gelu_erf
     else:
-        keras.utils.get_custom_objects()['gelu'] = gelu_tanh
+        keras.utils.get_custom_objects()["gelu"] = gelu_tanh
 
 
 def piecewise_linear(t, schedule, from_zero=True):
@@ -156,8 +150,7 @@ def reshape(tensor, *args):
 
 
 def flatten(tensor, start=None, end=None):
-    """将tensor从start到end的维度展平
-    """
+    """将tensor从start到end的维度展平"""
     start, end = start or 0, end or K.ndim(tensor)
     shape = K.shape(tensor)
     shape = [s or shape[i] for i, s in enumerate(K.int_shape(tensor))]
@@ -166,8 +159,7 @@ def flatten(tensor, start=None, end=None):
 
 
 def dtype(x):
-    """增强K.dtype的容错性
-    """
+    """增强K.dtype的容错性"""
     try:
         return K.dtype(x)
     except:
@@ -175,8 +167,7 @@ def dtype(x):
 
 
 def where(cond, x, y):
-    """给tf.where加上自动广播
-    """
+    """给tf.where加上自动广播"""
     shape = tf.broadcast_dynamic_shape(K.shape(x), K.shape(y))
     shape = tf.broadcast_dynamic_shape(K.shape(cond), shape)
 
@@ -191,16 +182,14 @@ def where(cond, x, y):
         x = tf.broadcast_to(x, shape)
         y = tf.broadcast_to(y, shape)
 
-    if dtype(cond) != 'bool':
-        cond = K.cast(cond, 'bool')
+    if dtype(cond) != "bool":
+        cond = K.cast(cond, "bool")
 
     cond = tf.broadcast_to(cond, shape)
     return tf.where(cond, x, y)
 
 
-def sequence_masking(
-    x, mask=None, value=0, axis=None, bias=None, return_mask=False
-):
+def sequence_masking(x, mask=None, value=0, axis=None, bias=None, return_mask=False):
     """为序列条件mask的函数
     mask: 形如(batch_size, seq_len)的bool矩阵；
     value: mask部分要被替换成的值，可以是'-inf'或'inf'；
@@ -210,7 +199,7 @@ def sequence_masking(
     """
     if not (mask is None and bias is None):
         if mask is None:
-            if K.dtype(bias) == 'bool':
+            if K.dtype(bias) == "bool":
                 mask = bias
                 x = K.where(mask, x, value)
             else:
@@ -225,8 +214,8 @@ def sequence_masking(
 
             axes = [axis if axis >= 0 else K.ndim(x) + axis for axis in axes]
 
-            if K.dtype(mask) != 'bool':
-                mask = K.cast(mask, 'bool')
+            if K.dtype(mask) != "bool":
+                mask = K.cast(mask, "bool")
 
             full_mask = align(mask, [0, axes[0]], K.ndim(x))
             for axis in axes[1:]:
@@ -235,7 +224,7 @@ def sequence_masking(
             mask = full_mask
             if bias is None:
                 x = K.where(mask, x, value)
-            elif K.dtype(bias) == 'bool':
+            elif K.dtype(bias) == "bool":
                 mask = mask & bias
                 x = K.where(mask, x, value)
             else:
@@ -248,10 +237,9 @@ def sequence_masking(
 
 
 def batch_gather(params, indices):
-    """同tf旧版本的batch_gather
-    """
-    if K.dtype(indices)[:3] != 'int':
-        indices = K.cast(indices, 'int32')
+    """同tf旧版本的batch_gather"""
+    if K.dtype(indices)[:3] != "int":
+        indices = K.cast(indices, "int32")
 
     try:
         return tf.gather(params, indices, batch_dims=K.ndim(indices) - 1)
@@ -259,19 +247,11 @@ def batch_gather(params, indices):
         try:
             return tf.batch_gather(params, indices)
         except Exception as e2:
-            raise ValueError('%s\n%s\n' % (e1.message, e2.message))
+            raise ValueError("%s\n%s\n" % (e1.message, e2.message))
 
 
-def pool1d(
-    x,
-    pool_size,
-    strides=1,
-    padding='valid',
-    data_format=None,
-    pool_mode='max'
-):
-    """向量序列的pool函数
-    """
+def pool1d(x, pool_size, strides=1, padding="valid", data_format=None, pool_mode="max"):
+    """向量序列的pool函数"""
     x = K.expand_dims(x, 1)
     x = K.pool2d(
         x,
@@ -279,45 +259,74 @@ def pool1d(
         strides=(1, strides),
         padding=padding,
         data_format=data_format,
-        pool_mode=pool_mode
+        pool_mode=pool_mode,
     )
     return x[:, 0]
 
 
 def divisible_temporal_padding(x, n):
-    """将一维向量序列右padding到长度能被n整除
-    """
+    """将一维向量序列右padding到长度能被n整除"""
     r_len = K.shape(x)[1] % n
     p_len = K.where(r_len > 0, n - r_len, 0)
     return K.temporal_padding(x, (0, p_len))
 
 
 def root_mean_square(x, axis=None, keepdims=False):
-    """均方根，相当于模长的变体
-    """
+    """均方根，相当于模长的变体"""
     return K.sqrt(K.mean(K.square(x), axis=axis, keepdims=keepdims))
 
 
 def swish(x):
-    """swish函数（这样封装过后才有 __name__ 属性）
-    """
+    """swish函数（这样封装过后才有 __name__ 属性）"""
     return tf.nn.swish(x)
 
 
 def leaky_relu(x, alpha=0.2):
-    """leaky relu函数（这样封装过后才有 __name__ 属性）
-    """
+    """leaky relu函数（这样封装过后才有 __name__ 属性）"""
     return tf.nn.leaky_relu(x, alpha=alpha)
 
 
-def attention_normalize(a, mask=None, axis=-1, method='softmax', bias=None):
+def sparsemax(logits, axis=-1):
+    """
+    Compute the sparsemax activation along the specified axis.
+
+    Args:
+        logits: A tensor of logits.
+        axis: The axis along which to apply sparsemax.
+
+    Returns:
+        A tensor with the same shape as logits where sparsemax has been applied.
+    """
+    logits = tf.convert_to_tensor(logits)
+    # for numerical stability
+    z = logits - tf.reduce_max(logits, axis=axis, keepdims=True)
+    # sort z in descending order.
+    z_sorted = tf.sort(z, direction="DESCENDING", axis=axis)
+    z_cumsum = tf.cumsum(z_sorted, axis=axis)
+
+    r = tf.cast(tf.range(1, tf.shape(z)[axis] + 1), logits.dtype)
+    r_shape = [1] * tf.rank(z)
+    r_shape[axis] = -1
+    r = tf.reshape(r, r_shape)
+
+    # determine the support
+    support = tf.cast(r * z_sorted > (z_cumsum - 1), logits.dtype)
+    k_z = tf.reduce_sum(support, axis=axis, keepdims=True)
+    tau_sum = tf.reduce_sum(z_sorted * support, axis=axis, keepdims=True)
+    tau = (tau_sum - 1) / k_z
+    return tf.maximum(z - tau, 0)
+
+
+def attention_normalize(a, mask=None, axis=-1, method="sparsemax", bias=None):
     """不同的注意力归一化方案
     softmax：常规/标准的指数归一化；
     squared_relu：来自 https://arxiv.org/abs/2202.10447 ；
     softmax_plus：来自 https://kexue.fm/archives/8823 。
     """
     a, mask = sequence_masking(a, mask, -np.inf, axis, bias, True)
-    if method == 'softmax':
+    if method == "sparsemax":
+        return sparsemax(a, axis=axis)
+    elif method == "softmax":
         return K.softmax(a, axis=axis)
     else:
         if mask is None:
@@ -325,21 +334,20 @@ def attention_normalize(a, mask=None, axis=-1, method='softmax', bias=None):
         else:
             mask = K.cast(mask, K.floatx())
             l = K.sum(mask, axis=axis, keepdims=True)
-        if method == 'squared_relu':
-            return K.relu(a)**2 / l
-        elif method == 'softmax_plus':
+        if method == "squared_relu":
+            return K.relu(a) ** 2 / l
+        elif method == "softmax_plus":
             l = K.maximum(l, 16)  # 极短序列scale反而不好
             return K.softmax(a * K.log(l) / np.log(512), axis=axis)
     return a
 
 
 def sinusoidal_embeddings(pos, dim, base=10000):
-    """计算pos位置的dim维sinusoidal编码
-    """
+    """计算pos位置的dim维sinusoidal编码"""
     assert dim % 2 == 0
     indices = K.arange(0, dim // 2, dtype=K.floatx())
     indices = K.pow(K.cast(base, K.floatx()), -2 * indices / dim)
-    embeddings = tf.einsum('...,d->...d', pos, indices)
+    embeddings = tf.einsum("...,d->...d", pos, indices)
     embeddings = K.stack([K.sin(embeddings), K.cos(embeddings)], axis=-1)
     embeddings = K.flatten(embeddings, -2)
     return embeddings
@@ -349,9 +357,9 @@ class Sinusoidal(keras.initializers.Initializer):
     """Sin-Cos位置向量初始化器
     来自：https://arxiv.org/abs/1706.03762
     """
+
     def __call__(self, shape, dtype=None):
-        """Sin-Cos形式的位置向量
-        """
+        """Sin-Cos形式的位置向量"""
         size, dim = shape
         return sinusoidal_embeddings(K.arange(size, dtype=K.floatx()), dim)
 
@@ -361,10 +369,10 @@ def apply_rotary_position_embeddings(sinusoidal, *tensors):
     其中，sinusoidal.shape=[b, n, d]，tensors为tensor的列表，而
     tensor.shape=[b, n, ..., d]。
     """
-    assert len(tensors) > 0, 'at least one input tensor'
-    assert all([
-        K.int_shape(tensor) == K.int_shape(tensors[0]) for tensor in tensors[1:]
-    ]), 'all tensors must have the same shape'
+    assert len(tensors) > 0, "at least one input tensor"
+    assert all(
+        [K.int_shape(tensor) == K.int_shape(tensors[0]) for tensor in tensors[1:]]
+    ), "all tensors must have the same shape"
     ndim = K.ndim(tensors[0])
     sinusoidal = align(sinusoidal, [0, 1, -1], ndim)
     cos_pos = K.repeat_elements(sinusoidal[..., 1::2], 2, -1)
@@ -430,15 +438,13 @@ def sparse_multilabel_categorical_crossentropy(y_true, y_pred, mask_zero=False):
 
 
 def symbolic(f):
-    """恒等装饰器（兼容旧版本keras用）
-    """
+    """恒等装饰器（兼容旧版本keras用）"""
     return f
 
 
 def graph_mode_decorator(f, *args, **kwargs):
-    """tf 2.1与之前版本的传参方式不一样，这里做个同步
-    """
-    if tf.__version__ < '2.1':
+    """tf 2.1与之前版本的传参方式不一样，这里做个同步"""
+    if tf.__version__ < "2.1":
         return _graph_mode_decorator(f, *args, **kwargs)
     else:
         return _graph_mode_decorator(f, args, kwargs)
@@ -457,18 +463,16 @@ def recompute_grad(call):
         """
         flat_inputs = nest.flatten(inputs)
         call_args = tf_inspect.getfullargspec(call).args
-        for key in ['mask', 'training']:
+        for key in ["mask", "training"]:
             if key not in call_args and key in kwargs:
                 del kwargs[key]
 
         def kernel_call():
-            """定义前向计算
-            """
+            """定义前向计算"""
             return call(self, inputs, **kwargs)
 
         def call_and_grad(*inputs):
-            """定义前向计算和反向计算
-            """
+            """定义前向计算和反向计算"""
             if is_tf_keras:
                 with tape.stop_recording():
                     outputs = kernel_call()
@@ -484,11 +488,9 @@ def recompute_grad(call):
                     t.watch(watches)
                     with tf.control_dependencies([doutputs]):
                         outputs = kernel_call()
-                grads = t.gradient(
-                    outputs, watches, output_gradients=[doutputs]
-                )
+                grads = t.gradient(outputs, watches, output_gradients=[doutputs])
                 del t
-                return grads[:len(inputs)], grads[len(inputs):]
+                return grads[: len(inputs)], grads[len(inputs) :]
 
             return outputs, grad_fn
 
@@ -502,9 +504,7 @@ def recompute_grad(call):
 
             watches = flat_inputs + self.trainable_weights
             watches = [tf.convert_to_tensor(x) for x in watches]
-            tape.record_operation(
-                call.__name__, flat_outputs, watches, actual_grad_fn
-            )
+            tape.record_operation(call.__name__, flat_outputs, watches, actual_grad_fn)
             return outputs
         else:  # keras + tf >= 1.14 均可用
             return graph_mode_decorator(call_and_grad, *flat_inputs)
@@ -513,27 +513,27 @@ def recompute_grad(call):
 
 
 # 给旧版keras新增symbolic（装饰器），以兼容optimizers.py
-K.symbolic = getattr(K, 'symbolic', None) or symbolic
+K.symbolic = getattr(K, "symbolic", None) or symbolic
 
 # 给tf.keras补充上logsumexp
-K.logsumexp = getattr(K, 'logsumexp', None) or tf.math.reduce_logsumexp
+K.logsumexp = getattr(K, "logsumexp", None) or tf.math.reduce_logsumexp
 
 # 添加到 keras.backend 上，使其可以像 K.epsilon() 那样操作
 K.reshape = reshape
 K.flatten = flatten
 K.where = where
-sys.modules['tensorflow.keras.backend'] = K
+sys.modules["tensorflow.keras.backend"] = K
 
 custom_objects = {
-    'gelu_erf': gelu_erf,
-    'gelu_tanh': gelu_tanh,
-    'gelu': gelu_erf,
-    'root_mean_square': root_mean_square,
-    'swish': swish,
-    'leaky_relu': leaky_relu,
-    'Sinusoidal': Sinusoidal,
-    'multilabel_categorical_crossentropy': multilabel_categorical_crossentropy,
-    'initializer': keras.initializers.glorot_uniform,  # 就当是默认初始化方案吧
+    "gelu_erf": gelu_erf,
+    "gelu_tanh": gelu_tanh,
+    "gelu": gelu_erf,
+    "root_mean_square": root_mean_square,
+    "swish": swish,
+    "leaky_relu": leaky_relu,
+    "Sinusoidal": Sinusoidal,
+    "multilabel_categorical_crossentropy": multilabel_categorical_crossentropy,
+    "initializer": keras.initializers.glorot_uniform,  # 就当是默认初始化方案吧
 }
 
 keras.utils.get_custom_objects().update(custom_objects)

--- a/bert4keras/layers.py
+++ b/bert4keras/layers.py
@@ -14,12 +14,12 @@ from keras.layers import *
 
 
 def integerize_shape(func):
-    """装饰器，保证input_shape一定是int或None
-    """
+    """装饰器，保证input_shape一定是int或None"""
+
     def convert(item):
-        if hasattr(item, '__iter__'):
+        if hasattr(item, "__iter__"):
             return [convert(i) for i in item]
-        elif hasattr(item, 'value'):
+        elif hasattr(item, "value"):
             return item.value
         else:
             return item
@@ -31,19 +31,20 @@ def integerize_shape(func):
     return new_func
 
 
-if (not is_tf_keras) and keras.__version__ < '2.3':
+if (not is_tf_keras) and keras.__version__ < "2.3":
 
     class Layer(keras.layers.Layer):
         """重新定义Layer，赋予“层中层”功能
         （仅keras 2.3以下版本需要）
         """
+
         def __init__(self, **kwargs):
             super(Layer, self).__init__(**kwargs)
             self.supports_masking = True  # 本项目的自定义层均可mask
 
         def __setattr__(self, name, value):
             if isinstance(value, keras.layers.Layer):
-                if not hasattr(self, '_layers'):
+                if not hasattr(self, "_layers"):
                     self._layers = []
                 if value not in self._layers:
                     self._layers.append(value)
@@ -51,10 +52,10 @@ if (not is_tf_keras) and keras.__version__ < '2.3':
 
         @property
         def trainable_weights(self):
-            trainable = getattr(self, 'trainable', True)
+            trainable = getattr(self, "trainable", True)
             if trainable:
                 trainable_weights = super(Layer, self).trainable_weights[:]
-                for l in getattr(self, '_layers', []):
+                for l in getattr(self, "_layers", []):
                     trainable_weights += l.trainable_weights
                 return trainable_weights
             else:
@@ -62,22 +63,22 @@ if (not is_tf_keras) and keras.__version__ < '2.3':
 
         @property
         def non_trainable_weights(self):
-            trainable = getattr(self, 'trainable', True)
+            trainable = getattr(self, "trainable", True)
             non_trainable_weights = super(Layer, self).non_trainable_weights[:]
-            for l in getattr(self, '_layers', []):
+            for l in getattr(self, "_layers", []):
                 if trainable:
                     non_trainable_weights += l.non_trainable_weights
                 else:
                     non_trainable_weights += l.weights
             return non_trainable_weights
 
-    if keras.__version__ < '2.2.5':
+    if keras.__version__ < "2.2.5":
 
         import inspect
 
         class Model(keras.models.Model):
-            """重新定义Model，整合fit和fit_generator
-            """
+            """重新定义Model，整合fit和fit_generator"""
+
             def fit(self, x=None, *args, **kwargs):
                 if inspect.isgenerator(x):
                     return self.fit_generator(x, *args, **kwargs)
@@ -94,12 +95,13 @@ else:
             self.supports_masking = True  # 本项目的自定义层均可mask
 
 
-if (not is_tf_keras) or tf.__version__ < '1.15':
+if (not is_tf_keras) or tf.__version__ < "1.15":
 
     if not is_tf_keras:
         NodeBase = keras.engine.base_layer.Node
     else:
         from tensorflow.python.keras.engine import base_layer
+
         NodeBase = base_layer.Node
 
     class Node(NodeBase):
@@ -108,6 +110,7 @@ if (not is_tf_keras) or tf.__version__ < '1.15':
              所以只好在这里进行修改。tf 1.15+自带的keras已经修改了这个
              bug。
         """
+
         @property
         def arguments(self):
             return self._arguments.copy()
@@ -123,10 +126,10 @@ if (not is_tf_keras) or tf.__version__ < '1.15':
 
 
 class GlobalAveragePooling1D(keras.layers.GlobalAveragePooling1D):
-    """重新定义GlobalAveragePooling1D，支持序列长度为None
-    """
+    """重新定义GlobalAveragePooling1D，支持序列长度为None"""
+
     def call(self, inputs, mask=None):
-        axis = 1 if self.data_format == 'channels_last' else 2
+        axis = 1 if self.data_format == "channels_last" else 2
         if mask is not None:
             mask = K.cast(mask, K.floatx())
             mask = mask[..., None] if axis == 1 else mask[:, None]
@@ -136,14 +139,14 @@ class GlobalAveragePooling1D(keras.layers.GlobalAveragePooling1D):
 
 
 class GlobalMaxPooling1D(keras.layers.GlobalMaxPooling1D):
-    """重新定义GlobalMaxPooling1D，支持mask
-    """
-    def __init__(self, data_format='channels_last', **kwargs):
+    """重新定义GlobalMaxPooling1D，支持mask"""
+
+    def __init__(self, data_format="channels_last", **kwargs):
         super(GlobalMaxPooling1D, self).__init__(data_format, **kwargs)
         self.supports_masking = True
 
     def call(self, inputs, mask=None):
-        axis = 1 if self.data_format == 'channels_last' else 2
+        axis = 1 if self.data_format == "channels_last" else 2
         inputs = sequence_masking(inputs, mask, -np.inf, axis)
         return K.max(inputs, axis=axis)
 
@@ -157,25 +160,24 @@ keras.layers.GlobalMaxPooling1D = GlobalMaxPooling1D
 
 
 class Embedding(keras.layers.Embedding):
-    """拓展Embedding层
-    """
+    """拓展Embedding层"""
+
     def compute_mask(self, inputs, mask=None):
-        """为了适配T5，保证第一个token不被mask
-        """
+        """为了适配T5，保证第一个token不被mask"""
         if K.ndim(inputs) == 2:
             mask = super(Embedding, self).compute_mask(inputs, mask)
             if mask is not None:
-                mask1 = K.ones_like(mask[:, :1], dtype='bool')
+                mask1 = K.ones_like(mask[:, :1], dtype="bool")
                 mask2 = mask[:, 1:]
                 return K.concatenate([mask1, mask2], 1)
         else:
             return mask
 
-    def call(self, inputs, mode='embedding'):
+    def call(self, inputs, mode="embedding"):
         """新增mode参数，可以为embedding或dense。如果为embedding，
         则等价于普通Embedding层；如果为dense，则等价于无bias的Dense层。
         """
-        if mode == 'embedding':
+        if mode == "embedding":
             return super(Embedding, self).call(inputs)
         else:
             kernel = K.transpose(self.embeddings)
@@ -199,14 +201,15 @@ class ScaleOffset(Layer):
          3、hidden_*系列参数仅为有条件输入时(conditional=True)使用，
             用于通过外部条件控制beta和gamma。
     """
+
     def __init__(
         self,
         scale=True,
         offset=True,
         conditional=False,
         hidden_units=None,
-        hidden_activation='linear',
-        hidden_initializer='glorot_uniform',
+        hidden_activation="linear",
+        hidden_initializer="glorot_uniform",
         **kwargs
     ):
         super(ScaleOffset, self).__init__(**kwargs)
@@ -226,11 +229,11 @@ class ScaleOffset(Layer):
 
         if self.offset is True:
             self.beta = self.add_weight(
-                name='beta', shape=(input_shape[-1],), initializer='zeros'
+                name="beta", shape=(input_shape[-1],), initializer="zeros"
             )
         if self.scale is True:
             self.gamma = self.add_weight(
-                name='gamma', shape=(input_shape[-1],), initializer='ones'
+                name="gamma", shape=(input_shape[-1],), initializer="ones"
             )
 
         if self.conditional:
@@ -240,20 +243,16 @@ class ScaleOffset(Layer):
                     units=self.hidden_units,
                     activation=self.hidden_activation,
                     use_bias=False,
-                    kernel_initializer=self.hidden_initializer
+                    kernel_initializer=self.hidden_initializer,
                 )
 
             if self.offset is not False and self.offset is not None:
                 self.beta_dense = Dense(
-                    units=input_shape[-1],
-                    use_bias=False,
-                    kernel_initializer='zeros'
+                    units=input_shape[-1], use_bias=False, kernel_initializer="zeros"
                 )
             if self.scale is not False and self.scale is not None:
                 self.gamma_dense = Dense(
-                    units=input_shape[-1],
-                    use_bias=False,
-                    kernel_initializer='zeros'
+                    units=input_shape[-1], use_bias=False, kernel_initializer="zeros"
                 )
 
     def compute_mask(self, inputs, mask=None):
@@ -264,8 +263,7 @@ class ScaleOffset(Layer):
 
     @recompute_grad
     def call(self, inputs):
-        """如果带有条件，则默认以list为输入，第二个是条件
-        """
+        """如果带有条件，则默认以list为输入，第二个是条件"""
         if self.conditional:
             inputs, conds = inputs
             if self.hidden_units is not None:
@@ -294,13 +292,12 @@ class ScaleOffset(Layer):
 
     def get_config(self):
         config = {
-            'scale': self.scale,
-            'offset': self.offset,
-            'conditional': self.conditional,
-            'hidden_units': self.hidden_units,
-            'hidden_activation': activations.serialize(self.hidden_activation),
-            'hidden_initializer':
-                initializers.serialize(self.hidden_initializer),
+            "scale": self.scale,
+            "offset": self.offset,
+            "conditional": self.conditional,
+            "hidden_units": self.hidden_units,
+            "hidden_activation": activations.serialize(self.hidden_activation),
+            "hidden_initializer": initializers.serialize(self.hidden_initializer),
         }
         base_config = super(ScaleOffset, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -313,6 +310,7 @@ class Concatenate1D(Layer):
          带mask的序列与一个不带mask的序列拼接会报错，因此干脆
          自己重写一个好了。
     """
+
     def call(self, inputs):
         return K.concatenate(inputs, axis=1)
 
@@ -321,7 +319,7 @@ class Concatenate1D(Layer):
             masks = []
             for i, m in enumerate(mask):
                 if m is None:
-                    m = K.ones_like(inputs[i][..., 0], dtype='bool')
+                    m = K.ones_like(inputs[i][..., 0], dtype="bool")
                 masks.append(m)
             return K.concatenate(masks, axis=1)
 
@@ -337,6 +335,7 @@ class BatchSplit(Layer):
     """将第一维进行分割
     主要是用于自行实现多卡数据并行。
     """
+
     def __init__(self, parts, **kwargs):
         super(BatchSplit, self).__init__(**kwargs)
         self.parts = parts
@@ -360,32 +359,28 @@ class BatchSplit(Layer):
 
         batch_size = K.shape(inputs)[0]
         if np.ndim(self.parts) > 0:
-            batch_size = K.cast(batch_size, 'float64')
+            batch_size = K.cast(batch_size, "float64")
             slices = [
-                K.cast(p * batch_size / sum(self.parts), 'int32')
-                for p in np.cumsum(self.parts).astype('float64')
+                K.cast(p * batch_size / sum(self.parts), "int32")
+                for p in np.cumsum(self.parts).astype("float64")
             ]
         else:
-            stride = K.cast(
-                tf.math.ceil(batch_size / self.parts), K.dtype(batch_size)
-            )
+            stride = K.cast(tf.math.ceil(batch_size / self.parts), K.dtype(batch_size))
             slices = [stride * (i + 1) for i in range(self.parts)]
 
         for i, _ in enumerate(slices):
             if i == 0:
-                outputs.append(inputs[:slices[0]])
+                outputs.append(inputs[: slices[0]])
             elif i == len(slices) - 1:
-                outputs.append(inputs[slices[-2]:])
+                outputs.append(inputs[slices[-2] :])
             else:
-                outputs.append(inputs[slices[i - 1]:slices[i]])
+                outputs.append(inputs[slices[i - 1] : slices[i]])
 
         return outputs
 
     def compute_output_shape(self, input_shape):
         if isinstance(input_shape, list):
-            return [
-                o for i in input_shape for o in self.compute_output_shape(i)
-            ]
+            return [o for i in input_shape for o in self.compute_output_shape(i)]
 
         if np.ndim(self.parts) > 0:
             return [input_shape] * len(self.parts)
@@ -394,7 +389,7 @@ class BatchSplit(Layer):
 
     def get_config(self):
         config = {
-            'parts': self.parts,
+            "parts": self.parts,
         }
         base_config = super(BatchSplit, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -404,6 +399,7 @@ class BatchConcat(Layer):
     """将第一维进行合并
     主要是用于自行实现多卡数据并行。
     """
+
     def compute_mask(self, inputs, mask=None):
         if isinstance(mask, list):
             if all([m is not None for m in mask]):
@@ -417,8 +413,8 @@ class BatchConcat(Layer):
 
 
 class MultiHeadAttention(Layer):
-    """多头注意力机制
-    """
+    """多头注意力机制"""
+
     def __init__(
         self,
         heads,
@@ -426,11 +422,11 @@ class MultiHeadAttention(Layer):
         out_dim=None,
         key_size=None,
         use_bias=True,
-        normalization='softmax',
+        normalization="sparsemax",
         attention_scale=True,
         attention_dropout=None,
         return_attention_scores=False,
-        kernel_initializer='glorot_uniform',
+        kernel_initializer="glorot_uniform",
         **kwargs
     ):
         super(MultiHeadAttention, self).__init__(**kwargs)
@@ -450,22 +446,22 @@ class MultiHeadAttention(Layer):
         self.q_dense = Dense(
             units=self.key_size * self.heads,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
         self.k_dense = Dense(
             units=self.key_size * self.heads,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
         self.v_dense = Dense(
             units=self.head_size * self.heads,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
         self.o_dense = Dense(
             units=self.out_dim,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
 
     @recompute_grad
@@ -512,19 +508,19 @@ class MultiHeadAttention(Layer):
         """
         (qw, kw, vw), n = inputs[:3], 3
         q_mask, v_mask = mask
-        a_bias, p_bias = kwargs.get('a_bias'), kwargs.get('p_bias')
+        a_bias, p_bias = kwargs.get("a_bias"), kwargs.get("p_bias")
         if a_bias:
             a_bias = inputs[n]
             n += 1
-        if p_bias == 'rotary':
+        if p_bias == "rotary":
             qw, kw = apply_rotary_position_embeddings(inputs[n], qw, kw)
         # Attention
-        a = tf.einsum('bjhd,bkhd->bhjk', qw, kw)
+        a = tf.einsum("bjhd,bkhd->bhjk", qw, kw)
         # 处理位置编码
-        if p_bias == 'typical_relative':
+        if p_bias == "typical_relative":
             position_bias = inputs[n]
-            a = a + tf.einsum('bjhd,jkd->bhjk', qw, position_bias)
-        elif p_bias == 't5_relative':
+            a = a + tf.einsum("bjhd,jkd->bhjk", qw, position_bias)
+        elif p_bias == "t5_relative":
             position_bias = K.permute_dimensions(inputs[n], (2, 0, 1))
             a = a + K.expand_dims(position_bias, 0)
         # Attention（续）
@@ -536,17 +532,19 @@ class MultiHeadAttention(Layer):
         if self.attention_dropout:
             A = Dropout(self.attention_dropout)(A)
         # 完成输出
-        o = tf.einsum('bhjk,bkhd->bjhd', A, vw)
-        if p_bias == 'typical_relative':
-            o = o + tf.einsum('bhjk,jkd->bjhd', A, position_bias)
+        o = tf.einsum("bhjk,bkhd->bjhd", A, vw)
+        if p_bias == "typical_relative":
+            o = o + tf.einsum("bhjk,jkd->bjhd", A, position_bias)
         return o, a
 
     def compute_output_shape(self, input_shape):
         o_shape = (input_shape[0][0], input_shape[0][1], self.out_dim)
         if self.return_attention_scores:
             a_shape = (
-                input_shape[0][0], self.heads, input_shape[0][1],
-                input_shape[1][1]
+                input_shape[0][0],
+                self.heads,
+                input_shape[0][1],
+                input_shape[1][1],
             )
             return [o_shape, a_shape]
         else:
@@ -561,17 +559,16 @@ class MultiHeadAttention(Layer):
 
     def get_config(self):
         config = {
-            'heads': self.heads,
-            'head_size': self.head_size,
-            'out_dim': self.out_dim,
-            'key_size': self.key_size,
-            'use_bias': self.use_bias,
-            'normalization': self.normalization,
-            'attention_scale': self.attention_scale,
-            'attention_dropout': self.attention_dropout,
-            'return_attention_scores': self.return_attention_scores,
-            'kernel_initializer':
-                initializers.serialize(self.kernel_initializer),
+            "heads": self.heads,
+            "head_size": self.head_size,
+            "out_dim": self.out_dim,
+            "key_size": self.key_size,
+            "use_bias": self.use_bias,
+            "normalization": self.normalization,
+            "attention_scale": self.attention_scale,
+            "attention_dropout": self.attention_dropout,
+            "return_attention_scores": self.return_attention_scores,
+            "kernel_initializer": initializers.serialize(self.kernel_initializer),
         }
         base_config = super(MultiHeadAttention, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -584,17 +581,18 @@ class GatedAttentionUnit(Layer):
     说明：没有加入加性相对位置编码，个人认为是不必要的；如果觉得有必要，
          可以自行通过a_bias传入。
     """
+
     def __init__(
         self,
         units,
         key_size,
-        activation='swish',
+        activation="swish",
         use_bias=True,
-        normalization='squared_relu',
+        normalization="squared_relu",
         self_attention=True,
         attention_scale=True,
         attention_dropout=None,
-        kernel_initializer='glorot_uniform',
+        kernel_initializer="glorot_uniform",
         **kwargs
     ):
         super(GatedAttentionUnit, self).__init__(**kwargs)
@@ -619,7 +617,7 @@ class GatedAttentionUnit(Layer):
                 units=2 * self.units + self.key_size,
                 activation=self.activation,
                 use_bias=self.use_bias,
-                kernel_initializer=self.kernel_initializer
+                kernel_initializer=self.kernel_initializer,
             )
             self.q_scaleoffset = ScaleOffset(offset=self.use_bias)
             self.k_scaleoffset = ScaleOffset(offset=self.use_bias)
@@ -628,24 +626,24 @@ class GatedAttentionUnit(Layer):
                 units=self.units + self.key_size,
                 activation=self.activation,
                 use_bias=self.use_bias,
-                kernel_initializer=self.kernel_initializer
+                kernel_initializer=self.kernel_initializer,
             )
             self.k_dense = Dense(
                 units=self.key_size,
                 activation=self.activation,
                 use_bias=self.use_bias,
-                kernel_initializer=self.kernel_initializer
+                kernel_initializer=self.kernel_initializer,
             )
             self.v_dense = Dense(
                 units=self.units,
                 activation=self.activation,
                 use_bias=self.use_bias,
-                kernel_initializer=self.kernel_initializer
+                kernel_initializer=self.kernel_initializer,
             )
         self.o_dense = Dense(
             units=hidden_size,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
 
     @recompute_grad
@@ -670,17 +668,17 @@ class GatedAttentionUnit(Layer):
             u, q = tf.split(uq, [self.units, self.key_size], -1)
             k, v = self.k_dense(k), self.v_dense(v)
         # 加入RoPE
-        if p_bias == 'rotary':
+        if p_bias == "rotary":
             q, k = apply_rotary_position_embeddings(inputs[n], q, k)
         # Attention
-        a = tf.einsum('bmd,bnd->bmn', q, k)
+        a = tf.einsum("bmd,bnd->bmn", q, k)
         if self.attention_scale:
             a = a / self.key_size**0.5
         A = attention_normalize(a, mask, -1, self.normalization, a_bias)
         if self.attention_dropout:
             A = Dropout(self.attention_dropout)(A)
         # 计算输出
-        o = self.o_dense(u * tf.einsum('bmn,bnd->bmd', A, v))
+        o = self.o_dense(u * tf.einsum("bmn,bnd->bmd", A, v))
         return o
 
     def compute_mask(self, inputs, mask=None):
@@ -697,27 +695,24 @@ class GatedAttentionUnit(Layer):
 
     def get_config(self):
         config = {
-            'units': self.units,
-            'key_size': self.key_size,
-            'activation': activations.serialize(self.activation),
-            'use_bias': self.use_bias,
-            'normalization': self.normalization,
-            'self_attention': self.self_attention,
-            'attention_scale': self.attention_scale,
-            'attention_dropout': self.attention_dropout,
-            'kernel_initializer':
-                initializers.serialize(self.kernel_initializer),
+            "units": self.units,
+            "key_size": self.key_size,
+            "activation": activations.serialize(self.activation),
+            "use_bias": self.use_bias,
+            "normalization": self.normalization,
+            "self_attention": self.self_attention,
+            "attention_scale": self.attention_scale,
+            "attention_dropout": self.attention_dropout,
+            "kernel_initializer": initializers.serialize(self.kernel_initializer),
         }
         base_config = super(GatedAttentionUnit, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 
 class LayerNormalization(ScaleOffset):
-    """(Conditional) Layer Normalization
-    """
-    def __init__(
-        self, zero_mean=True, unit_variance=True, epsilon=None, **kwargs
-    ):
+    """(Conditional) Layer Normalization"""
+
+    def __init__(self, zero_mean=True, unit_variance=True, epsilon=None, **kwargs):
         super(LayerNormalization, self).__init__(**kwargs)
         self.zero_mean = zero_mean
         self.unit_variance = unit_variance
@@ -725,8 +720,7 @@ class LayerNormalization(ScaleOffset):
 
     @recompute_grad
     def call(self, inputs):
-        """如果是条件Layer Norm，则默认以list为输入，第二个是条件
-        """
+        """如果是条件Layer Norm，则默认以list为输入，第二个是条件"""
         if self.conditional:
             inputs, conds = inputs
 
@@ -735,9 +729,7 @@ class LayerNormalization(ScaleOffset):
             inputs = inputs - mean
         if self.unit_variance:
             variance = K.mean(K.square(inputs), axis=-1, keepdims=True)
-            inputs = tf.math.divide_no_nan(
-                inputs, K.sqrt(variance + self.epsilon)
-            )
+            inputs = tf.math.divide_no_nan(inputs, K.sqrt(variance + self.epsilon))
 
         if self.conditional:
             inputs = [inputs, conds]
@@ -746,24 +738,24 @@ class LayerNormalization(ScaleOffset):
 
     def get_config(self):
         config = {
-            'zero_mean': self.zero_mean,
-            'unit_variance': self.unit_variance,
-            'epsilon': self.epsilon,
+            "zero_mean": self.zero_mean,
+            "unit_variance": self.unit_variance,
+            "epsilon": self.epsilon,
         }
         base_config = super(LayerNormalization, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 
 class PositionEmbedding(Layer):
-    """定义可训练的位置Embedding
-    """
+    """定义可训练的位置Embedding"""
+
     def __init__(
         self,
         input_dim,
         output_dim,
-        merge_mode='add',
+        merge_mode="add",
         hierarchical=None,
-        embeddings_initializer='zeros',
+        embeddings_initializer="zeros",
         custom_position_ids=False,
         **kwargs
     ):
@@ -778,22 +770,21 @@ class PositionEmbedding(Layer):
     def build(self, input_shape):
         super(PositionEmbedding, self).build(input_shape)
         self.embeddings = self.add_weight(
-            name='embeddings',
+            name="embeddings",
             shape=(self.input_dim, self.output_dim),
-            initializer=self.embeddings_initializer
+            initializer=self.embeddings_initializer,
         )
 
     def call(self, inputs):
-        """如果custom_position_ids，那么第二个输入为自定义的位置id
-        """
+        """如果custom_position_ids，那么第二个输入为自定义的位置id"""
         if self.custom_position_ids:
             inputs, position_ids = inputs
-            if 'int' not in K.dtype(position_ids):
-                position_ids = K.cast(position_ids, 'int32')
+            if "int" not in K.dtype(position_ids):
+                position_ids = K.cast(position_ids, "int32")
         else:
             input_shape = K.shape(inputs)
             batch_size, seq_len = input_shape[0], input_shape[1]
-            position_ids = K.arange(0, seq_len, dtype='int32')[None]
+            position_ids = K.arange(0, seq_len, dtype="int32")[None]
 
         if self.hierarchical:
             alpha = 0.4 if self.hierarchical is True else self.hierarchical
@@ -808,11 +799,11 @@ class PositionEmbedding(Layer):
             else:
                 embeddings = self.embeddings[None, :seq_len]
 
-        if self.merge_mode == 'add':
+        if self.merge_mode == "add":
             return inputs + embeddings
-        elif self.merge_mode == 'mul':
+        elif self.merge_mode == "mul":
             return inputs * (embeddings + 1.0)
-        elif self.merge_mode == 'zero':
+        elif self.merge_mode == "zero":
             return embeddings
         else:
             if not self.custom_position_ids:
@@ -823,34 +814,31 @@ class PositionEmbedding(Layer):
         if self.custom_position_ids:
             input_shape = input_shape[0]
 
-        if self.merge_mode in ['add', 'mul', 'zero']:
+        if self.merge_mode in ["add", "mul", "zero"]:
             return input_shape[:2] + (self.output_dim,)
         else:
             return input_shape[:2] + (input_shape[2] + self.output_dim,)
 
     def get_config(self):
         config = {
-            'input_dim': self.input_dim,
-            'output_dim': self.output_dim,
-            'merge_mode': self.merge_mode,
-            'hierarchical': self.hierarchical,
-            'embeddings_initializer':
-                initializers.serialize(self.embeddings_initializer),
-            'custom_position_ids': self.custom_position_ids,
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "merge_mode": self.merge_mode,
+            "hierarchical": self.hierarchical,
+            "embeddings_initializer": initializers.serialize(
+                self.embeddings_initializer
+            ),
+            "custom_position_ids": self.custom_position_ids,
         }
         base_config = super(PositionEmbedding, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 
 class SinusoidalPositionEmbedding(Layer):
-    """定义Sin-Cos位置Embedding
-    """
+    """定义Sin-Cos位置Embedding"""
+
     def __init__(
-        self,
-        output_dim,
-        merge_mode='add',
-        custom_position_ids=False,
-        **kwargs
+        self, output_dim, merge_mode="add", custom_position_ids=False, **kwargs
     ):
         super(SinusoidalPositionEmbedding, self).__init__(**kwargs)
         self.output_dim = output_dim
@@ -858,11 +846,10 @@ class SinusoidalPositionEmbedding(Layer):
         self.custom_position_ids = custom_position_ids
 
     def call(self, inputs):
-        """如果custom_position_ids，那么第二个输入为自定义的位置id
-        """
+        """如果custom_position_ids，那么第二个输入为自定义的位置id"""
         if self.custom_position_ids:
             inputs, position_ids = inputs
-            if 'float' not in K.dtype(position_ids):
+            if "float" not in K.dtype(position_ids):
                 position_ids = K.cast(position_ids, K.floatx())
         else:
             input_shape = K.shape(inputs)
@@ -871,11 +858,11 @@ class SinusoidalPositionEmbedding(Layer):
 
         embeddings = sinusoidal_embeddings(position_ids, self.output_dim)
 
-        if self.merge_mode == 'add':
+        if self.merge_mode == "add":
             return inputs + embeddings
-        elif self.merge_mode == 'mul':
+        elif self.merge_mode == "mul":
             return inputs * (embeddings + 1.0)
-        elif self.merge_mode == 'zero':
+        elif self.merge_mode == "zero":
             return embeddings
         else:
             if not self.custom_position_ids:
@@ -886,16 +873,16 @@ class SinusoidalPositionEmbedding(Layer):
         if self.custom_position_ids:
             input_shape = input_shape[0]
 
-        if self.merge_mode in ['add', 'mul', 'zero']:
+        if self.merge_mode in ["add", "mul", "zero"]:
             return input_shape[:2] + (self.output_dim,)
         else:
             return input_shape[:2] + (input_shape[2] + self.output_dim,)
 
     def get_config(self):
         config = {
-            'output_dim': self.output_dim,
-            'merge_mode': self.merge_mode,
-            'custom_position_ids': self.custom_position_ids,
+            "output_dim": self.output_dim,
+            "merge_mode": self.merge_mode,
+            "custom_position_ids": self.custom_position_ids,
         }
         base_config = super(SinusoidalPositionEmbedding, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -905,9 +892,8 @@ class RelativePositionEmbedding(Layer):
     """相对位置编码
     来自论文：https://arxiv.org/abs/1803.02155
     """
-    def __init__(
-        self, input_dim, output_dim, embeddings_initializer='zeros', **kwargs
-    ):
+
+    def __init__(self, input_dim, output_dim, embeddings_initializer="zeros", **kwargs):
         super(RelativePositionEmbedding, self).__init__(**kwargs)
         self.input_dim = input_dim
         self.output_dim = output_dim
@@ -916,7 +902,7 @@ class RelativePositionEmbedding(Layer):
     def build(self, input_shape):
         super(RelativePositionEmbedding, self).build(input_shape)
         self.embeddings = self.add_weight(
-            name='embeddings',
+            name="embeddings",
             shape=(self.input_dim, self.output_dim),
             initializer=self.embeddings_initializer,
         )
@@ -928,9 +914,9 @@ class RelativePositionEmbedding(Layer):
     def compute_position_ids(self, inputs):
         q, v = inputs
         # 计算位置差
-        q_idxs = K.arange(0, K.shape(q)[1], dtype='int32')
+        q_idxs = K.arange(0, K.shape(q)[1], dtype="int32")
         q_idxs = K.expand_dims(q_idxs, 1)
-        v_idxs = K.arange(0, K.shape(v)[1], dtype='int32')
+        v_idxs = K.arange(0, K.shape(v)[1], dtype="int32")
         v_idxs = K.expand_dims(v_idxs, 0)
         pos_ids = v_idxs - q_idxs
         # 后处理操作
@@ -947,10 +933,11 @@ class RelativePositionEmbedding(Layer):
 
     def get_config(self):
         config = {
-            'input_dim': self.input_dim,
-            'output_dim': self.output_dim,
-            'embeddings_initializer':
-                initializers.serialize(self.embeddings_initializer),
+            "input_dim": self.input_dim,
+            "output_dim": self.output_dim,
+            "embeddings_initializer": initializers.serialize(
+                self.embeddings_initializer
+            ),
         }
         base_config = super(RelativePositionEmbedding, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -960,28 +947,29 @@ class RelativePositionEmbeddingT5(RelativePositionEmbedding):
     """Google T5的相对位置编码
     来自论文：https://arxiv.org/abs/1910.10683
     """
+
     def __init__(
         self,
         input_dim,
         output_dim,
         max_distance=128,
         bidirectional=True,
-        embeddings_initializer='zeros',
+        embeddings_initializer="zeros",
         **kwargs
     ):
-        super(RelativePositionEmbeddingT5,
-              self).__init__(input_dim, output_dim, **kwargs)
+        super(RelativePositionEmbeddingT5, self).__init__(
+            input_dim, output_dim, **kwargs
+        )
         self.max_distance = max_distance
         self.bidirectional = bidirectional
 
     def compute_position_ids(self, inputs):
-        """T5的相对位置分桶（直接翻译自官方T5源码）
-        """
+        """T5的相对位置分桶（直接翻译自官方T5源码）"""
         q, v = inputs
         # 计算位置差
-        q_idxs = K.arange(0, K.shape(q)[1], dtype='int32')
+        q_idxs = K.arange(0, K.shape(q)[1], dtype="int32")
         q_idxs = K.expand_dims(q_idxs, 1)
-        v_idxs = K.arange(0, K.shape(v)[1], dtype='int32')
+        v_idxs = K.arange(0, K.shape(v)[1], dtype="int32")
         v_idxs = K.expand_dims(v_idxs, 0)
         pos_ids = v_idxs - q_idxs
         # 后处理操作
@@ -990,7 +978,7 @@ class RelativePositionEmbeddingT5(RelativePositionEmbedding):
         n = -pos_ids
         if self.bidirectional:
             num_buckets //= 2
-            ret += K.cast(K.less(n, 0), 'int32') * num_buckets
+            ret += K.cast(K.less(n, 0), "int32") * num_buckets
             n = K.abs(n)
         else:
             n = K.maximum(n, 0)
@@ -998,9 +986,10 @@ class RelativePositionEmbeddingT5(RelativePositionEmbedding):
         max_exact = num_buckets // 2
         is_small = K.less(n, max_exact)
         val_if_large = max_exact + K.cast(
-            K.log(K.cast(n, K.floatx()) / max_exact) /
-            np.log(max_distance / max_exact) * (num_buckets - max_exact),
-            'int32',
+            K.log(K.cast(n, K.floatx()) / max_exact)
+            / np.log(max_distance / max_exact)
+            * (num_buckets - max_exact),
+            "int32",
         )
         val_if_large = K.minimum(val_if_large, num_buckets - 1)
         ret += K.where(is_small, n, val_if_large)
@@ -1008,8 +997,8 @@ class RelativePositionEmbeddingT5(RelativePositionEmbedding):
 
     def get_config(self):
         config = {
-            'max_distance': self.max_distance,
-            'bidirectional': self.bidirectional,
+            "max_distance": self.max_distance,
+            "bidirectional": self.bidirectional,
         }
         base_config = super(RelativePositionEmbeddingT5, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -1021,12 +1010,13 @@ class FeedForward(Layer):
     一个list，那么第一个Dense层将会被替换成门控线性单元（Gated Linear Unit）。
     参考论文: https://arxiv.org/abs/2002.05202
     """
+
     def __init__(
         self,
         units,
-        activation='relu',
+        activation="relu",
         use_bias=True,
-        kernel_initializer='glorot_uniform',
+        kernel_initializer="glorot_uniform",
         **kwargs
     ):
         super(FeedForward, self).__init__(**kwargs)
@@ -1047,33 +1037,30 @@ class FeedForward(Layer):
                 units=self.units,
                 activation=activation,
                 use_bias=self.use_bias,
-                kernel_initializer=self.kernel_initializer
+                kernel_initializer=self.kernel_initializer,
             )
-            setattr(self, 'i%s_dense' % i, i_dense)
+            setattr(self, "i%s_dense" % i, i_dense)
 
         self.o_dense = Dense(
             units=output_dim,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
 
     @recompute_grad
     def call(self, inputs):
         x = self.i0_dense(inputs)
         for i in range(1, len(self.activation)):
-            x = x * getattr(self, 'i%s_dense' % i)(inputs)
+            x = x * getattr(self, "i%s_dense" % i)(inputs)
         x = self.o_dense(x)
         return x
 
     def get_config(self):
         config = {
-            'units': self.units,
-            'activation': [
-                activations.serialize(act) for act in self.activation
-            ],
-            'use_bias': self.use_bias,
-            'kernel_initializer':
-                initializers.serialize(self.kernel_initializer),
+            "units": self.units,
+            "activation": [activations.serialize(act) for act in self.activation],
+            "use_bias": self.use_bias,
+            "kernel_initializer": initializers.serialize(self.kernel_initializer),
         }
         base_config = super(FeedForward, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -1083,6 +1070,7 @@ class ConditionalRandomField(Layer):
     """纯Keras实现CRF层
     CRF层本质上是一个带训练参数的loss计算层。
     """
+
     def __init__(self, lr_multiplier=1, **kwargs):
         super(ConditionalRandomField, self).__init__(**kwargs)
         self.lr_multiplier = lr_multiplier  # 当前层学习率的放大倍数
@@ -1092,9 +1080,7 @@ class ConditionalRandomField(Layer):
         super(ConditionalRandomField, self).build(input_shape)
         output_dim = input_shape[-1]
         self._trans = self.add_weight(
-            name='trans',
-            shape=(output_dim, output_dim),
-            initializer='glorot_uniform'
+            name="trans", shape=(output_dim, output_dim), initializer="glorot_uniform"
         )
         if self.lr_multiplier != 1:
             K.set_value(self._trans, K.eval(self._trans) / self.lr_multiplier)
@@ -1116,9 +1102,9 @@ class ConditionalRandomField(Layer):
         """计算目标路径的相对概率（还没有归一化）
         要点：逐标签得分，加上转移概率得分。
         """
-        point_score = tf.einsum('bni,bni->b', y_true, y_pred)  # 逐标签得分
+        point_score = tf.einsum("bni,bni->b", y_true, y_pred)  # 逐标签得分
         trans_score = tf.einsum(
-            'bni,ij,bnj->b', y_true[:, :-1], self.trans, y_true[:, 1:]
+            "bni,ij,bnj->b", y_true[:, :-1], self.trans, y_true[:, 1:]
         )  # 标签转移得分
         return point_score + trans_score
 
@@ -1135,8 +1121,7 @@ class ConditionalRandomField(Layer):
         return outputs, [outputs]
 
     def dense_loss(self, y_true, y_pred):
-        """y_true需要是one hot形式
-        """
+        """y_true需要是one hot形式"""
         # 导出mask并转换数据类型
         mask = K.all(K.not_equal(y_pred, -np.inf), axis=2, keepdims=True)
         # 计算目标分数
@@ -1149,21 +1134,17 @@ class ConditionalRandomField(Layer):
         y_pred = K.concatenate([y_pred, mask], axis=2)
         input_length = K.int_shape(y_pred[:, 1:])[1]
         log_norm, _, _ = K.rnn(
-            self.log_norm_step,
-            y_pred[:, 1:],
-            init_states,
-            input_length=input_length
+            self.log_norm_step, y_pred[:, 1:], init_states, input_length=input_length
         )  # 最后一步的log Z向量
         log_norm = K.logsumexp(log_norm, 1)  # logsumexp得标量
         # 计算损失 -log p
         return log_norm - target_score
 
     def sparse_loss(self, y_true, y_pred):
-        """y_true需要是整数形式（非one hot）
-        """
+        """y_true需要是整数形式（非one hot）"""
         # y_true需要重新明确一下shape和dtype
         y_true = K.reshape(y_true, K.shape(y_pred)[:-1])
-        y_true = K.cast(y_true, 'int32')
+        y_true = K.cast(y_true, "int32")
         # 转为one hot
         y_true = K.one_hot(y_true, K.shape(self.trans)[0])
         return self.dense_loss(y_true, y_pred)
@@ -1184,15 +1165,15 @@ class ConditionalRandomField(Layer):
         mask = K.cast(mask, K.floatx())
         # y_true需要重新明确一下shape和dtype
         y_true = K.reshape(y_true, K.shape(y_pred)[:-1])
-        y_true = K.cast(y_true, 'int32')
+        y_true = K.cast(y_true, "int32")
         # 逐标签取最大来粗略评测训练效果
-        y_pred = K.cast(K.argmax(y_pred, 2), 'int32')
+        y_pred = K.cast(K.argmax(y_pred, 2), "int32")
         isequal = K.cast(K.equal(y_true, y_pred), K.floatx())
         return K.sum(isequal * mask) / K.sum(mask)
 
     def get_config(self):
         config = {
-            'lr_multiplier': self.lr_multiplier,
+            "lr_multiplier": self.lr_multiplier,
         }
         base_config = super(ConditionalRandomField, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -1202,6 +1183,7 @@ class MaximumEntropyMarkovModel(Layer):
     """（双向）最大熵隐马尔可夫模型
     作用和用法都类似CRF，但是比CRF更快更简单。
     """
+
     def __init__(self, lr_multiplier=1, hidden_dim=None, **kwargs):
         super(MaximumEntropyMarkovModel, self).__init__(**kwargs)
         self.lr_multiplier = lr_multiplier  # 当前层学习率的放大倍数
@@ -1214,36 +1196,27 @@ class MaximumEntropyMarkovModel(Layer):
 
         if self.hidden_dim is None:
             self._trans = self.add_weight(
-                name='trans',
+                name="trans",
                 shape=(output_dim, output_dim),
-                initializer='glorot_uniform'
+                initializer="glorot_uniform",
             )
             if self.lr_multiplier != 1:
-                K.set_value(
-                    self._trans,
-                    K.eval(self._trans) / self.lr_multiplier
-                )
+                K.set_value(self._trans, K.eval(self._trans) / self.lr_multiplier)
         else:
             self._l_trans = self.add_weight(
-                name='l_trans',
+                name="l_trans",
                 shape=(output_dim, self.hidden_dim),
-                initializer='glorot_uniform'
+                initializer="glorot_uniform",
             )
             self._r_trans = self.add_weight(
-                name='r_trans',
+                name="r_trans",
                 shape=(output_dim, self.hidden_dim),
-                initializer='glorot_uniform'
+                initializer="glorot_uniform",
             )
 
             if self.lr_multiplier != 1:
-                K.set_value(
-                    self._l_trans,
-                    K.eval(self._l_trans) / self.lr_multiplier
-                )
-                K.set_value(
-                    self._r_trans,
-                    K.eval(self._r_trans) / self.lr_multiplier
-                )
+                K.set_value(self._l_trans, K.eval(self._l_trans) / self.lr_multiplier)
+                K.set_value(self._r_trans, K.eval(self._r_trans) / self.lr_multiplier)
 
     @property
     def trans(self):
@@ -1276,18 +1249,17 @@ class MaximumEntropyMarkovModel(Layer):
         if mask is None:
             return [x[:, ::-1] for x in inputs]
         else:
-            length = K.cast(K.sum(mask, 1), 'int32')
+            length = K.cast(K.sum(mask, 1), "int32")
             return [tf.reverse_sequence(x, length, seq_axis=1) for x in inputs]
 
     def basic_loss(self, y_true, y_pred, go_backwards=False):
-        """y_true需要是整数形式（非one hot）
-        """
+        """y_true需要是整数形式（非one hot）"""
         # 导出mask并转换数据类型
         mask = K.all(K.not_equal(y_pred, -np.inf), axis=2)
         mask = K.cast(mask, K.floatx())
         # y_true需要重新明确一下shape和dtype
         y_true = K.reshape(y_true, K.shape(y_pred)[:-1])
-        y_true = K.cast(y_true, 'int32')
+        y_true = K.cast(y_true, "int32")
         # 反转相关
         if self.hidden_dim is None:
             if go_backwards:  # 是否反转序列
@@ -1303,25 +1275,21 @@ class MaximumEntropyMarkovModel(Layer):
             else:
                 l_trans, r_trans = self.l_trans, self.r_trans
             history = K.gather(l_trans, y_true)
-            history = tf.einsum('bnd,kd->bnk', history, r_trans)
+            history = tf.einsum("bnd,kd->bnk", history, r_trans)
         # 计算loss
         history = K.concatenate([y_pred[:, :1], history[:, :-1]], 1)
         y_pred = K.where(mask[..., None], (y_pred + history) / 2, 0)
-        loss = K.sparse_categorical_crossentropy(
-            y_true, y_pred, from_logits=True
-        )
+        loss = K.sparse_categorical_crossentropy(y_true, y_pred, from_logits=True)
         return K.sum(loss * mask) / K.sum(mask)
 
     def sparse_loss(self, y_true, y_pred):
-        """y_true需要是整数形式（非one hot）
-        """
+        """y_true需要是整数形式（非one hot）"""
         loss = self.basic_loss(y_true, y_pred, False)
         loss = loss + self.basic_loss(y_true, y_pred, True)
         return loss / 2
 
     def dense_loss(self, y_true, y_pred):
-        """y_true需要是one hot形式
-        """
+        """y_true需要是one hot形式"""
         y_true = K.argmax(y_true, 2)
         return self.sparse_loss(y_true, y_pred)
 
@@ -1334,7 +1302,7 @@ class MaximumEntropyMarkovModel(Layer):
         mask = K.cast(mask, K.floatx())
         # y_true需要重新明确一下shape和dtype
         y_true = K.reshape(y_true, K.shape(y_pred)[:-1])
-        y_true = K.cast(y_true, 'int32')
+        y_true = K.cast(y_true, "int32")
         # 反转相关
         if self.hidden_dim is None:
             if go_backwards:  # 是否反转序列
@@ -1350,11 +1318,11 @@ class MaximumEntropyMarkovModel(Layer):
             else:
                 l_trans, r_trans = self.l_trans, self.r_trans
             history = K.gather(l_trans, y_true)
-            history = tf.einsum('bnd,kd->bnk', history, r_trans)
+            history = tf.einsum("bnd,kd->bnk", history, r_trans)
         # 计算逐标签accuracy
         history = K.concatenate([y_pred[:, :1], history[:, :-1]], 1)
         y_pred = (y_pred + history) / 2
-        y_pred = K.cast(K.argmax(y_pred, 2), 'int32')
+        y_pred = K.cast(K.argmax(y_pred, 2), "int32")
         isequal = K.cast(K.equal(y_true, y_pred), K.floatx())
         return K.sum(isequal * mask) / K.sum(mask)
 
@@ -1375,8 +1343,8 @@ class MaximumEntropyMarkovModel(Layer):
 
     def get_config(self):
         config = {
-            'lr_multiplier': self.lr_multiplier,
-            'hidden_dim': self.hidden_dim,
+            "lr_multiplier": self.lr_multiplier,
+            "hidden_dim": self.hidden_dim,
         }
         base_config = super(MaximumEntropyMarkovModel, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -1387,6 +1355,7 @@ class GlobalPointer(Layer):
     将序列的每个(start, end)作为整体来进行判断
     参考：https://kexue.fm/archives/8373
     """
+
     def __init__(
         self,
         heads,
@@ -1394,7 +1363,7 @@ class GlobalPointer(Layer):
         RoPE=True,
         use_bias=True,
         tril_mask=True,
-        kernel_initializer='lecun_normal',
+        kernel_initializer="lecun_normal",
         **kwargs
     ):
         super(GlobalPointer, self).__init__(**kwargs)
@@ -1410,7 +1379,7 @@ class GlobalPointer(Layer):
         self.dense = Dense(
             units=self.head_size * self.heads * 2,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
 
     def compute_mask(self, inputs, mask=None):
@@ -1422,17 +1391,17 @@ class GlobalPointer(Layer):
         inputs = self.dense(inputs)
         inputs = tf.split(inputs, self.heads, axis=-1)
         inputs = K.stack(inputs, axis=-2)
-        qw, kw = inputs[..., :self.head_size], inputs[..., self.head_size:]
+        qw, kw = inputs[..., : self.head_size], inputs[..., self.head_size :]
         # RoPE编码
         if self.RoPE:
-            pos = SinusoidalPositionEmbedding(self.head_size, 'zero')(inputs)
+            pos = SinusoidalPositionEmbedding(self.head_size, "zero")(inputs)
             qw, kw = apply_rotary_position_embeddings(pos, qw, kw)
         # 计算内积
-        logits = tf.einsum('bmhd,bnhd->bhmn', qw, kw) / self.head_size**0.5
+        logits = tf.einsum("bmhd,bnhd->bhmn", qw, kw) / self.head_size**0.5
         # 排除下三角
         if self.tril_mask:
             tril_mask = tf.linalg.band_part(K.ones_like(logits[0, 0]), 0, -1)
-            tril_mask = K.cast(tril_mask, 'bool')
+            tril_mask = K.cast(tril_mask, "bool")
         else:
             tril_mask = None
         # 返回最终结果
@@ -1443,13 +1412,12 @@ class GlobalPointer(Layer):
 
     def get_config(self):
         config = {
-            'heads': self.heads,
-            'head_size': self.head_size,
-            'RoPE': self.RoPE,
-            'use_bias': self.use_bias,
-            'tril_mask': self.tril_mask,
-            'kernel_initializer':
-                initializers.serialize(self.kernel_initializer),
+            "heads": self.heads,
+            "head_size": self.head_size,
+            "RoPE": self.RoPE,
+            "use_bias": self.use_bias,
+            "tril_mask": self.tril_mask,
+            "kernel_initializer": initializers.serialize(self.kernel_initializer),
         }
         base_config = super(GlobalPointer, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -1459,16 +1427,17 @@ class EfficientGlobalPointer(GlobalPointer):
     """更加参数高效的GlobalPointer
     参考：https://kexue.fm/archives/8877
     """
+
     def build(self, input_shape):
         self.p_dense = Dense(
             units=self.head_size * 2,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
         self.q_dense = Dense(
             units=self.heads * 2,
             use_bias=self.use_bias,
-            kernel_initializer=self.kernel_initializer
+            kernel_initializer=self.kernel_initializer,
         )
         self.built = True
 
@@ -1479,16 +1448,16 @@ class EfficientGlobalPointer(GlobalPointer):
         qw, kw = inputs[..., ::2], inputs[..., 1::2]
         # RoPE编码
         if self.RoPE:
-            pos = SinusoidalPositionEmbedding(self.head_size, 'zero')(inputs)
+            pos = SinusoidalPositionEmbedding(self.head_size, "zero")(inputs)
             qw, kw = apply_rotary_position_embeddings(pos, qw, kw)
         # 计算内积
-        logits = tf.einsum('bmd,bnd->bmn', qw, kw) / self.head_size**0.5
-        bias = tf.einsum('bnh->bhn', self.q_dense(inputs)) / 2
+        logits = tf.einsum("bmd,bnd->bmn", qw, kw) / self.head_size**0.5
+        bias = tf.einsum("bnh->bhn", self.q_dense(inputs)) / 2
         logits = logits[:, None] + bias[:, ::2, None] + bias[:, 1::2, :, None]
         # 排除下三角
         if self.tril_mask:
             tril_mask = tf.linalg.band_part(K.ones_like(logits[0, 0]), 0, -1)
-            tril_mask = K.cast(tril_mask, 'bool')
+            tril_mask = K.cast(tril_mask, "bool")
         else:
             tril_mask = None
         # 返回最终结果
@@ -1496,8 +1465,8 @@ class EfficientGlobalPointer(GlobalPointer):
 
 
 class Loss(Layer):
-    """特殊的层，用来定义复杂loss
-    """
+    """特殊的层，用来定义复杂loss"""
+
     def __init__(self, output_axis=None, **kwargs):
         super(Loss, self).__init__(**kwargs)
         self.output_axis = output_axis
@@ -1534,31 +1503,31 @@ class Loss(Layer):
 
     def get_config(self):
         config = {
-            'output_axis': self.output_axis,
+            "output_axis": self.output_axis,
         }
         base_config = super(Loss, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
 
 
 custom_objects = {
-    'Embedding': Embedding,
-    'ScaleOffset': ScaleOffset,
-    'Concatenate1D': Concatenate1D,
-    'BatchSplit': BatchSplit,
-    'BatchConcat': BatchConcat,
-    'MultiHeadAttention': MultiHeadAttention,
-    'GatedAttentionUnit': GatedAttentionUnit,
-    'LayerNormalization': LayerNormalization,
-    'PositionEmbedding': PositionEmbedding,
-    'SinusoidalPositionEmbedding': SinusoidalPositionEmbedding,
-    'RelativePositionEmbedding': RelativePositionEmbedding,
-    'RelativePositionEmbeddingT5': RelativePositionEmbeddingT5,
-    'FeedForward': FeedForward,
-    'ConditionalRandomField': ConditionalRandomField,
-    'MaximumEntropyMarkovModel': MaximumEntropyMarkovModel,
-    'GlobalPointer': GlobalPointer,
-    'EfficientGlobalPointer': EfficientGlobalPointer,
-    'Loss': Loss,
+    "Embedding": Embedding,
+    "ScaleOffset": ScaleOffset,
+    "Concatenate1D": Concatenate1D,
+    "BatchSplit": BatchSplit,
+    "BatchConcat": BatchConcat,
+    "MultiHeadAttention": MultiHeadAttention,
+    "GatedAttentionUnit": GatedAttentionUnit,
+    "LayerNormalization": LayerNormalization,
+    "PositionEmbedding": PositionEmbedding,
+    "SinusoidalPositionEmbedding": SinusoidalPositionEmbedding,
+    "RelativePositionEmbedding": RelativePositionEmbedding,
+    "RelativePositionEmbeddingT5": RelativePositionEmbeddingT5,
+    "FeedForward": FeedForward,
+    "ConditionalRandomField": ConditionalRandomField,
+    "MaximumEntropyMarkovModel": MaximumEntropyMarkovModel,
+    "GlobalPointer": GlobalPointer,
+    "EfficientGlobalPointer": EfficientGlobalPointer,
+    "Loss": Loss,
 }
 
 keras.utils.get_custom_objects().update(custom_objects)

--- a/bert4keras/models.py
+++ b/bert4keras/models.py
@@ -13,8 +13,8 @@ import json
 
 
 class Transformer(object):
-    """模型基类
-    """
+    """模型基类"""
+
     def __init__(
         self,
         vocab_size,  # 词表大小
@@ -47,7 +47,9 @@ class Transformer(object):
         self.hidden_size = hidden_size
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
-        self.attention_head_size = attention_head_size or hidden_size // num_attention_heads
+        self.attention_head_size = (
+            attention_head_size or hidden_size // num_attention_heads
+        )
         self.attention_key_size = attention_key_size or self.attention_head_size
         self.intermediate_size = intermediate_size
         self.dropout_rate = dropout_rate or 0
@@ -64,7 +66,7 @@ class Transformer(object):
         self.ignore_invalid_weights = ignore_invalid_weights
         self.autoresize_weights = autoresize_weights
         self.layers = {} if layers is None else layers
-        self.prefix = prefix or ''
+        self.prefix = prefix or ""
         self.name = name
         self.built = False
 
@@ -93,7 +95,7 @@ class Transformer(object):
         self.layer_norm_conds = [
             layer_norm_cond,
             layer_norm_cond_hidden_size,
-            layer_norm_cond_hidden_act or 'linear',
+            layer_norm_cond_hidden_act or "linear",
         ]
         # Call
         outputs = self.call(inputs)
@@ -103,8 +105,7 @@ class Transformer(object):
         self.built = True
 
     def call(self, inputs):
-        """定义模型的执行流程
-        """
+        """定义模型的执行流程"""
         # Embedding
         outputs = self.apply_embeddings(inputs)
         # Main
@@ -115,8 +116,7 @@ class Transformer(object):
         return outputs
 
     def prefixed(self, name):
-        """给名字加前缀
-        """
+        """给名字加前缀"""
         if name is not None:
             return self.prefix + name
 
@@ -131,15 +131,15 @@ class Transformer(object):
             return inputs
 
         if layer is MultiHeadAttention and self.residual_attention_scores:
-            kwargs['return_attention_scores'] = True
+            kwargs["return_attention_scores"] = True
 
         arguments = arguments or {}
         if layer is Lambda:
-            kwargs['arguments'] = arguments
+            kwargs["arguments"] = arguments
             arguments = {}
 
-        name = self.prefixed(kwargs.get('name'))
-        kwargs['name'] = name
+        name = self.prefixed(kwargs.get("name"))
+        kwargs["name"] = name
         if name not in self.layers:
             layer = layer(**kwargs)
             name = layer.name
@@ -152,7 +152,7 @@ class Transformer(object):
                 if name in self.attention_caches:
                     # 如果检测到Cache的传入，那么自动在Key,Value处拼接起来
                     k_cache, v_cache = self.attention_caches[name]
-                    k_name, v_name = name + '-Cached-Key', name + '-Cached-Value'
+                    k_name, v_name = name + "-Cached-Key", name + "-Cached-Value"
                     k = Concatenate1D(name=k_name)([k_cache, inputs[1]])
                     v = Concatenate1D(name=v_name)([v_cache, inputs[2]])
                     inputs = inputs[:1] + [k, v] + inputs[3:]
@@ -161,14 +161,15 @@ class Transformer(object):
                     # 矩阵，这对应RealFormer设计（https://arxiv.org/abs/2012.11747）。目前
                     # 该实现还相对粗糙，可能欠缺通用性。
                     if self.attention_scores is not None:
-                        if arguments.get('a_bias'):
-                            a_bias = Add(name=name + '-Attention-Bias'
-                                        )([inputs[3], self.attention_scores])
+                        if arguments.get("a_bias"):
+                            a_bias = Add(name=name + "-Attention-Bias")(
+                                [inputs[3], self.attention_scores]
+                            )
                             inputs = inputs[:3] + [a_bias] + inputs[4:]
                         else:
                             a_bias = self.attention_scores
                             inputs = inputs[:3] + [a_bias] + inputs[3:]
-                        arguments['a_bias'] = True
+                        arguments["a_bias"] = True
                     o, a = self.layers[name](inputs, **arguments)
                     self.attention_scores = a
                     return o
@@ -187,18 +188,15 @@ class Transformer(object):
         raise NotImplementedError
 
     def compute_attention_bias(self, inputs=None):
-        """定义每一层的Attention Bias
-        """
+        """定义每一层的Attention Bias"""
         return self.attention_bias
 
     def compute_position_bias(self, inputs=None):
-        """定义每一层的Position Bias（一般相对位置编码用）
-        """
+        """定义每一层的Position Bias（一般相对位置编码用）"""
         return self.position_bias
 
     def set_inputs(self, inputs, additional_input_layers=None):
-        """设置input和inputs属性
-        """
+        """设置input和inputs属性"""
         if inputs is None:
             inputs = []
         elif not isinstance(inputs, list):
@@ -217,8 +215,7 @@ class Transformer(object):
             self.input = inputs[0]
 
     def set_outputs(self, outputs):
-        """设置output和outputs属性
-        """
+        """设置output和outputs属性"""
         if not isinstance(outputs, list):
             outputs = [outputs]
 
@@ -231,13 +228,11 @@ class Transformer(object):
 
     @property
     def initializer(self):
-        """默认使用截断正态分布初始化
-        """
+        """默认使用截断正态分布初始化"""
         return keras.initializers.TruncatedNormal(stddev=0.02)
 
     def simplify(self, inputs):
-        """将list中的None过滤掉
-        """
+        """将list中的None过滤掉"""
         inputs = [i for i in inputs if i is not None]
         if len(inputs) == 1:
             inputs = inputs[0]
@@ -245,8 +240,7 @@ class Transformer(object):
         return inputs
 
     def load_embeddings(self, embeddings):
-        """处理Embedding层权重
-        """
+        """处理Embedding层权重"""
         embeddings = embeddings.astype(K.floatx())  # 防止np.average报错
 
         if self.keep_tokens is not None:
@@ -257,37 +251,29 @@ class Transformer(object):
             for item in self.compound_tokens:
                 if isinstance(item, list):
                     item = (item, [1] * len(item))
-                ext_embeddings.append(
-                    np.average(embeddings[item[0]], 0, item[1])
-                )
+                ext_embeddings.append(np.average(embeddings[item[0]], 0, item[1]))
             embeddings = np.concatenate([embeddings, ext_embeddings], 0)
 
         return embeddings
 
     def load_variable(self, checkpoint, name):
-        """加载单个变量的函数
-        """
+        """加载单个变量的函数"""
         if isinstance(checkpoint, dict):
             return checkpoint[name]
         else:
             return tf.train.load_variable(checkpoint, name)
 
     def create_variable(self, name, value, dtype=None):
-        """创建一个变量
-        """
+        """创建一个变量"""
         dtype = dtype or K.floatx()
-        return K.variable(
-            self.initializer(value.shape, dtype), dtype, name=name
-        ), value
+        return K.variable(self.initializer(value.shape, dtype), dtype, name=name), value
 
     def variable_mapping(self):
-        """构建keras层与checkpoint的变量名之间的映射表
-        """
+        """构建keras层与checkpoint的变量名之间的映射表"""
         return {}
 
     def load_weights_from_checkpoint(self, checkpoint, mapping=None):
-        """根据mapping从checkpoint加载权重
-        """
+        """根据mapping从checkpoint加载权重"""
         mapping = mapping or self.variable_mapping()
         mapping = {self.prefixed(k): v for k, v in mapping.items()}
         mapping = {k: v for k, v in mapping.items() if k in self.layers}
@@ -303,7 +289,7 @@ class Transformer(object):
                     weights.append(w)
                 except Exception as e:
                     if self.ignore_invalid_weights:
-                        print('%s, but ignored.' % e.message)
+                        print("%s, but ignored." % e.message)
                     else:
                         raise e
 
@@ -323,7 +309,7 @@ class Transformer(object):
                             count = 1
                             if layer.use_bias:
                                 count += 1
-                            if self.hidden_act in ['relu', 'leaky_relu']:
+                            if self.hidden_act in ["relu", "leaky_relu"]:
                                 count -= 2
                             if i < count:
                                 v *= np.sqrt(1.0 * w_shape[-1] / v_shape[-1])
@@ -335,8 +321,7 @@ class Transformer(object):
         K.batch_set_value(weight_value_pairs)
 
     def save_weights_as_checkpoint(self, filename, mapping=None, dtype=None):
-        """根据mapping将权重保存为checkpoint格式
-        """
+        """根据mapping将权重保存为checkpoint格式"""
         mapping = mapping or self.variable_mapping()
         mapping = {self.prefixed(k): v for k, v in mapping.items()}
         mapping = {k: v for k, v in mapping.items() if k in self.layers}
@@ -357,11 +342,10 @@ class Transformer(object):
 
 
 class LM_Mask(object):
-    """定义下三角Attention Mask（语言模型用）
-    """
+    """定义下三角Attention Mask（语言模型用）"""
+
     def compute_attention_bias(self, inputs=None):
-        """通过idxs序列的比较来得到对应的mask
-        """
+        """通过idxs序列的比较来得到对应的mask"""
         if self.attention_bias is None:
 
             def lm_mask(s):
@@ -374,7 +358,7 @@ class LM_Mask(object):
                 inputs=self.inputs[0],
                 layer=Lambda,
                 function=lm_mask,
-                name='Attention-LM-Mask'
+                name="Attention-LM-Mask",
             )
 
         return self.attention_bias
@@ -385,9 +369,9 @@ class UniLM_Mask(object):
     其中source和target的分区，由segment_ids来表示。
     UniLM: https://arxiv.org/abs/1905.03197
     """
+
     def compute_attention_bias(self, inputs=None):
-        """通过idxs序列的比较来得到对应的mask
-        """
+        """通过idxs序列的比较来得到对应的mask"""
         if self.attention_bias is None:
 
             def unilm_mask(s):
@@ -399,15 +383,15 @@ class UniLM_Mask(object):
                 inputs=self.inputs[1],
                 layer=Lambda,
                 function=unilm_mask,
-                name='Attention-UniLM-Mask'
+                name="Attention-UniLM-Mask",
             )
 
         return self.attention_bias
 
 
 class BERT(Transformer):
-    """构建BERT模型
-    """
+    """构建BERT模型"""
+
     def __init__(
         self,
         max_position,  # 序列最大长度
@@ -437,31 +421,26 @@ class BERT(Transformer):
         （但允许自行传入位置id，以实现一些特殊需求）
         """
         x_in = self.apply(
-            layer=Input, shape=(self.sequence_length,), name='Input-Token'
+            layer=Input, shape=(self.sequence_length,), name="Input-Token"
         )
         inputs = [x_in]
 
         if self.segment_vocab_size > 0:
             s_in = self.apply(
-                layer=Input,
-                shape=(self.sequence_length,),
-                name='Input-Segment'
+                layer=Input, shape=(self.sequence_length,), name="Input-Segment"
             )
             inputs.append(s_in)
 
         if self.custom_position_ids:
             p_in = self.apply(
-                layer=Input,
-                shape=(self.sequence_length,),
-                name='Input-Position'
+                layer=Input, shape=(self.sequence_length,), name="Input-Position"
             )
             inputs.append(p_in)
 
         return inputs
 
     def apply_embeddings(self, inputs):
-        """BERT的embedding是token、position、segment三者embedding之和
-        """
+        """BERT的embedding是token、position、segment三者embedding之和"""
         inputs = inputs[:]
         x = inputs.pop(0)
         if self.segment_vocab_size > 0:
@@ -479,34 +458,32 @@ class BERT(Transformer):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         if self.segment_vocab_size > 0:
             if self.shared_segment_embeddings:
-                name = 'Embedding-Token'
+                name = "Embedding-Token"
             else:
-                name = 'Embedding-Segment'
+                name = "Embedding-Segment"
             s = self.apply(
                 inputs=s,
                 layer=Embedding,
                 input_dim=self.segment_vocab_size,
                 output_dim=self.embedding_size,
                 embeddings_initializer=self.initializer,
-                name=name
+                name=name,
             )
-            x = self.apply(
-                inputs=[x, s], layer=Add, name='Embedding-Token-Segment'
-            )
+            x = self.apply(inputs=[x, s], layer=Add, name="Embedding-Token-Segment")
         x = self.apply(
             inputs=self.simplify([x, p]),
             layer=PositionEmbedding,
             input_dim=self.max_position,
             output_dim=self.embedding_size,
-            merge_mode='add',
+            merge_mode="add",
             hierarchical=self.hierarchical_position,
             embeddings_initializer=self.initializer,
             custom_position_ids=self.custom_position_ids,
-            name='Embedding-Position'
+            name="Embedding-Position",
         )
         x = self.apply(
             inputs=self.simplify([x, z]),
@@ -516,13 +493,10 @@ class BERT(Transformer):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='Embedding-Norm'
+            name="Embedding-Norm",
         )
         x = self.apply(
-            inputs=x,
-            layer=Dropout,
-            rate=self.dropout_rate,
-            name='Embedding-Dropout'
+            inputs=x, layer=Dropout, rate=self.dropout_rate, name="Embedding-Dropout"
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -530,7 +504,7 @@ class BERT(Transformer):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Embedding-Mapping'
+                name="Embedding-Mapping",
             )
 
         return x
@@ -542,14 +516,14 @@ class BERT(Transformer):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Transformer-%d-FeedForward' % index
+        attention_name = "Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
 
         # Self Attention
-        xi, x, arguments = x, [x, x, x], {'a_bias': None}
+        xi, x, arguments = x, [x, x, x], {"a_bias": None}
         if attention_mask is not None:
-            arguments['a_bias'] = True
+            arguments["a_bias"] = True
             x.append(attention_mask)
 
         x = self.apply(
@@ -562,17 +536,15 @@ class BERT(Transformer):
             key_size=self.attention_key_size,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -581,7 +553,7 @@ class BERT(Transformer):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
 
         # Feed Forward
@@ -592,17 +564,15 @@ class BERT(Transformer):
             units=self.intermediate_size,
             activation=self.hidden_act,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -611,14 +581,13 @@ class BERT(Transformer):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
 
         return x
 
     def apply_final_layers(self, inputs):
-        """根据剩余参数决定输出
-        """
+        """根据剩余参数决定输出"""
         x = inputs
         z = self.layer_norm_conds[0]
         outputs = [x]
@@ -627,19 +596,16 @@ class BERT(Transformer):
             # Pooler部分（提取CLS向量）
             x = outputs[0]
             x = self.apply(
-                inputs=x,
-                layer=Lambda,
-                function=lambda x: x[:, 0],
-                name='Pooler'
+                inputs=x, layer=Lambda, function=lambda x: x[:, 0], name="Pooler"
             )
-            pool_activation = 'tanh' if self.with_pool is True else self.with_pool
+            pool_activation = "tanh" if self.with_pool is True else self.with_pool
             x = self.apply(
                 inputs=x,
                 layer=Dense,
                 units=self.hidden_size,
                 activation=pool_activation,
                 kernel_initializer=self.initializer,
-                name='Pooler-Dense'
+                name="Pooler-Dense",
             )
             if self.with_nsp:
                 # Next Sentence Prediction部分
@@ -647,9 +613,9 @@ class BERT(Transformer):
                     inputs=x,
                     layer=Dense,
                     units=2,
-                    activation='softmax',
+                    activation="sparsemax",
                     kernel_initializer=self.initializer,
-                    name='NSP-Proba'
+                    name="NSP-Proba",
                 )
             outputs.append(x)
 
@@ -662,7 +628,7 @@ class BERT(Transformer):
                 units=self.embedding_size,
                 activation=self.hidden_act,
                 kernel_initializer=self.initializer,
-                name='MLM-Dense'
+                name="MLM-Dense",
             )
             x = self.apply(
                 inputs=self.simplify([x, z]),
@@ -672,23 +638,21 @@ class BERT(Transformer):
                 hidden_units=self.layer_norm_conds[1],
                 hidden_activation=self.layer_norm_conds[2],
                 hidden_initializer=self.initializer,
-                name='MLM-Norm'
+                name="MLM-Norm",
             )
             x = self.apply(
                 inputs=x,
                 layer=Embedding,
-                arguments={'mode': 'dense'},
-                name='Embedding-Token'
+                arguments={"mode": "dense"},
+                name="Embedding-Token",
             )
-            x = self.apply(
-                inputs=x, layer=ScaleOffset, scale=False, name='MLM-Bias'
-            )
-            mlm_activation = 'softmax' if self.with_mlm is True else self.with_mlm
+            x = self.apply(inputs=x, layer=ScaleOffset, scale=False, name="MLM-Bias")
+            mlm_activation = "sparsemax" if self.with_mlm is True else self.with_mlm
             x = self.apply(
                 inputs=x,
                 layer=Activation,
                 activation=mlm_activation,
-                name='MLM-Activation'
+                name="MLM-Activation",
             )
             outputs.append(x)
 
@@ -702,95 +666,98 @@ class BERT(Transformer):
         return outputs
 
     def load_variable(self, checkpoint, name):
-        """加载单个变量的函数
-        """
+        """加载单个变量的函数"""
         variable = super(BERT, self).load_variable(checkpoint, name)
         if name in [
-            'bert/embeddings/word_embeddings',
-            'cls/predictions/output_bias',
+            "bert/embeddings/word_embeddings",
+            "cls/predictions/output_bias",
         ]:
             return self.load_embeddings(variable)
-        elif name == 'cls/seq_relationship/output_weights':
+        elif name == "cls/seq_relationship/output_weights":
             return variable.T
         else:
             return variable
 
     def create_variable(self, name, value, dtype=None):
-        """在tensorflow中创建一个变量
-        """
-        if name == 'cls/seq_relationship/output_weights':
+        """在tensorflow中创建一个变量"""
+        if name == "cls/seq_relationship/output_weights":
             value = value.T
         return super(BERT, self).create_variable(name, value, dtype)
 
     def variable_mapping(self):
-        """映射到官方BERT权重格式
-        """
+        """映射到官方BERT权重格式"""
         mapping = {
-            'Embedding-Token': ['bert/embeddings/word_embeddings'],
-            'Embedding-Segment': ['bert/embeddings/token_type_embeddings'],
-            'Embedding-Position': ['bert/embeddings/position_embeddings'],
-            'Embedding-Norm': [
-                'bert/embeddings/LayerNorm/beta',
-                'bert/embeddings/LayerNorm/gamma',
+            "Embedding-Token": ["bert/embeddings/word_embeddings"],
+            "Embedding-Segment": ["bert/embeddings/token_type_embeddings"],
+            "Embedding-Position": ["bert/embeddings/position_embeddings"],
+            "Embedding-Norm": [
+                "bert/embeddings/LayerNorm/beta",
+                "bert/embeddings/LayerNorm/gamma",
             ],
-            'Embedding-Mapping': [
-                'bert/encoder/embedding_hidden_mapping_in/kernel',
-                'bert/encoder/embedding_hidden_mapping_in/bias',
+            "Embedding-Mapping": [
+                "bert/encoder/embedding_hidden_mapping_in/kernel",
+                "bert/encoder/embedding_hidden_mapping_in/bias",
             ],
-            'Pooler-Dense': [
-                'bert/pooler/dense/kernel',
-                'bert/pooler/dense/bias',
+            "Pooler-Dense": [
+                "bert/pooler/dense/kernel",
+                "bert/pooler/dense/bias",
             ],
-            'NSP-Proba': [
-                'cls/seq_relationship/output_weights',
-                'cls/seq_relationship/output_bias',
+            "NSP-Proba": [
+                "cls/seq_relationship/output_weights",
+                "cls/seq_relationship/output_bias",
             ],
-            'MLM-Dense': [
-                'cls/predictions/transform/dense/kernel',
-                'cls/predictions/transform/dense/bias',
+            "MLM-Dense": [
+                "cls/predictions/transform/dense/kernel",
+                "cls/predictions/transform/dense/bias",
             ],
-            'MLM-Norm': [
-                'cls/predictions/transform/LayerNorm/beta',
-                'cls/predictions/transform/LayerNorm/gamma',
+            "MLM-Norm": [
+                "cls/predictions/transform/LayerNorm/beta",
+                "cls/predictions/transform/LayerNorm/gamma",
             ],
-            'MLM-Bias': ['cls/predictions/output_bias'],
+            "MLM-Bias": ["cls/predictions/output_bias"],
         }
 
         for i in range(self.num_hidden_layers):
-            prefix = 'bert/encoder/layer_%d/' % i
-            mapping.update({
-                'Transformer-%d-MultiHeadSelfAttention' % i: [
-                    prefix + 'attention/self/query/kernel',
-                    prefix + 'attention/self/query/bias',
-                    prefix + 'attention/self/key/kernel',
-                    prefix + 'attention/self/key/bias',
-                    prefix + 'attention/self/value/kernel',
-                    prefix + 'attention/self/value/bias',
-                    prefix + 'attention/output/dense/kernel',
-                    prefix + 'attention/output/dense/bias',
-                ],
-                'Transformer-%d-MultiHeadSelfAttention-Norm' % i: [
-                    prefix + 'attention/output/LayerNorm/beta',
-                    prefix + 'attention/output/LayerNorm/gamma',
-                ],
-                'Transformer-%d-FeedForward' % i: [
-                    prefix + 'intermediate/dense/kernel',
-                    prefix + 'intermediate/dense/bias',
-                    prefix + 'output/dense/kernel',
-                    prefix + 'output/dense/bias',
-                ],
-                'Transformer-%d-FeedForward-Norm' % i: [
-                    prefix + 'output/LayerNorm/beta',
-                    prefix + 'output/LayerNorm/gamma',
-                ],
-            })
+            prefix = "bert/encoder/layer_%d/" % i
+            mapping.update(
+                {
+                    "Transformer-%d-MultiHeadSelfAttention"
+                    % i: [
+                        prefix + "attention/self/query/kernel",
+                        prefix + "attention/self/query/bias",
+                        prefix + "attention/self/key/kernel",
+                        prefix + "attention/self/key/bias",
+                        prefix + "attention/self/value/kernel",
+                        prefix + "attention/self/value/bias",
+                        prefix + "attention/output/dense/kernel",
+                        prefix + "attention/output/dense/bias",
+                    ],
+                    "Transformer-%d-MultiHeadSelfAttention-Norm"
+                    % i: [
+                        prefix + "attention/output/LayerNorm/beta",
+                        prefix + "attention/output/LayerNorm/gamma",
+                    ],
+                    "Transformer-%d-FeedForward"
+                    % i: [
+                        prefix + "intermediate/dense/kernel",
+                        prefix + "intermediate/dense/bias",
+                        prefix + "output/dense/kernel",
+                        prefix + "output/dense/bias",
+                    ],
+                    "Transformer-%d-FeedForward-Norm"
+                    % i: [
+                        prefix + "output/LayerNorm/beta",
+                        prefix + "output/LayerNorm/gamma",
+                    ],
+                }
+            )
 
         return mapping
 
 
 class ALBERT(BERT):
-    """构建ALBERT模型
-    """
+    """构建ALBERT模型"""
+
     def apply_main_layers(self, inputs, index):
         """ALBERT的主体是基于Self-Attention的模块
         顺序：Att --> Add --> LN --> FFN --> Add --> LN
@@ -798,14 +765,14 @@ class ALBERT(BERT):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Transformer-MultiHeadSelfAttention'
-        feed_forward_name = 'Transformer-FeedForward'
+        attention_name = "Transformer-MultiHeadSelfAttention"
+        feed_forward_name = "Transformer-FeedForward"
         attention_mask = self.compute_attention_bias(index)
 
         # Self Attention
-        xi, x, arguments = x, [x, x, x], {'a_bias': None}
+        xi, x, arguments = x, [x, x, x], {"a_bias": None}
         if attention_mask is not None:
-            arguments['a_bias'] = True
+            arguments["a_bias"] = True
             x.append(attention_mask)
 
         x = self.apply(
@@ -818,17 +785,15 @@ class ALBERT(BERT):
             key_size=self.attention_key_size,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -836,7 +801,7 @@ class ALBERT(BERT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
 
         # Feed Forward
@@ -847,17 +812,15 @@ class ALBERT(BERT):
             units=self.intermediate_size,
             activation=self.hidden_act,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -865,83 +828,89 @@ class ALBERT(BERT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
 
         return x
 
     def variable_mapping(self):
-        """映射到官方ALBERT权重格式
-        """
+        """映射到官方ALBERT权重格式"""
         mapping = super(ALBERT, self).variable_mapping()
 
-        prefix = 'bert/encoder/transformer/group_0/inner_group_0/'
-        mapping.update({
-            'Transformer-MultiHeadSelfAttention': [
-                prefix + 'attention_1/self/query/kernel',
-                prefix + 'attention_1/self/query/bias',
-                prefix + 'attention_1/self/key/kernel',
-                prefix + 'attention_1/self/key/bias',
-                prefix + 'attention_1/self/value/kernel',
-                prefix + 'attention_1/self/value/bias',
-                prefix + 'attention_1/output/dense/kernel',
-                prefix + 'attention_1/output/dense/bias',
-            ],
-            'Transformer-MultiHeadSelfAttention-Norm': [
-                prefix + 'LayerNorm/beta',
-                prefix + 'LayerNorm/gamma',
-            ],
-            'Transformer-FeedForward': [
-                prefix + 'ffn_1/intermediate/dense/kernel',
-                prefix + 'ffn_1/intermediate/dense/bias',
-                prefix + 'ffn_1/intermediate/output/dense/kernel',
-                prefix + 'ffn_1/intermediate/output/dense/bias',
-            ],
-            'Transformer-FeedForward-Norm': [
-                prefix + 'LayerNorm_1/beta',
-                prefix + 'LayerNorm_1/gamma',
-            ],
-        })
+        prefix = "bert/encoder/transformer/group_0/inner_group_0/"
+        mapping.update(
+            {
+                "Transformer-MultiHeadSelfAttention": [
+                    prefix + "attention_1/self/query/kernel",
+                    prefix + "attention_1/self/query/bias",
+                    prefix + "attention_1/self/key/kernel",
+                    prefix + "attention_1/self/key/bias",
+                    prefix + "attention_1/self/value/kernel",
+                    prefix + "attention_1/self/value/bias",
+                    prefix + "attention_1/output/dense/kernel",
+                    prefix + "attention_1/output/dense/bias",
+                ],
+                "Transformer-MultiHeadSelfAttention-Norm": [
+                    prefix + "LayerNorm/beta",
+                    prefix + "LayerNorm/gamma",
+                ],
+                "Transformer-FeedForward": [
+                    prefix + "ffn_1/intermediate/dense/kernel",
+                    prefix + "ffn_1/intermediate/dense/bias",
+                    prefix + "ffn_1/intermediate/output/dense/kernel",
+                    prefix + "ffn_1/intermediate/output/dense/bias",
+                ],
+                "Transformer-FeedForward-Norm": [
+                    prefix + "LayerNorm_1/beta",
+                    prefix + "LayerNorm_1/gamma",
+                ],
+            }
+        )
 
         return mapping
 
 
 class ALBERT_Unshared(BERT):
-    """解开ALBERT共享约束，当成BERT用
-    """
+    """解开ALBERT共享约束，当成BERT用"""
+
     def variable_mapping(self):
-        """映射到官方ALBERT权重格式
-        """
+        """映射到官方ALBERT权重格式"""
         mapping = super(ALBERT_Unshared, self).variable_mapping()
 
-        prefix = 'bert/encoder/transformer/group_0/inner_group_0/'
+        prefix = "bert/encoder/transformer/group_0/inner_group_0/"
         for i in range(self.num_hidden_layers):
-            mapping.update({
-                'Transformer-%d-MultiHeadSelfAttention' % i: [
-                    prefix + 'attention_1/self/query/kernel',
-                    prefix + 'attention_1/self/query/bias',
-                    prefix + 'attention_1/self/key/kernel',
-                    prefix + 'attention_1/self/key/bias',
-                    prefix + 'attention_1/self/value/kernel',
-                    prefix + 'attention_1/self/value/bias',
-                    prefix + 'attention_1/output/dense/kernel',
-                    prefix + 'attention_1/output/dense/bias',
-                ],
-                'Transformer-%d-MultiHeadSelfAttention-Norm' % i: [
-                    prefix + 'LayerNorm/beta',
-                    prefix + 'LayerNorm/gamma',
-                ],
-                'Transformer-%d-FeedForward' % i: [
-                    prefix + 'ffn_1/intermediate/dense/kernel',
-                    prefix + 'ffn_1/intermediate/dense/bias',
-                    prefix + 'ffn_1/intermediate/output/dense/kernel',
-                    prefix + 'ffn_1/intermediate/output/dense/bias',
-                ],
-                'Transformer-%d-FeedForward-Norm' % i: [
-                    prefix + 'LayerNorm_1/beta',
-                    prefix + 'LayerNorm_1/gamma',
-                ],
-            })
+            mapping.update(
+                {
+                    "Transformer-%d-MultiHeadSelfAttention"
+                    % i: [
+                        prefix + "attention_1/self/query/kernel",
+                        prefix + "attention_1/self/query/bias",
+                        prefix + "attention_1/self/key/kernel",
+                        prefix + "attention_1/self/key/bias",
+                        prefix + "attention_1/self/value/kernel",
+                        prefix + "attention_1/self/value/bias",
+                        prefix + "attention_1/output/dense/kernel",
+                        prefix + "attention_1/output/dense/bias",
+                    ],
+                    "Transformer-%d-MultiHeadSelfAttention-Norm"
+                    % i: [
+                        prefix + "LayerNorm/beta",
+                        prefix + "LayerNorm/gamma",
+                    ],
+                    "Transformer-%d-FeedForward"
+                    % i: [
+                        prefix + "ffn_1/intermediate/dense/kernel",
+                        prefix + "ffn_1/intermediate/dense/bias",
+                        prefix + "ffn_1/intermediate/output/dense/kernel",
+                        prefix + "ffn_1/intermediate/output/dense/bias",
+                    ],
+                    "Transformer-%d-FeedForward-Norm"
+                    % i: [
+                        prefix + "LayerNorm_1/beta",
+                        prefix + "LayerNorm_1/gamma",
+                    ],
+                }
+            )
 
         return mapping
 
@@ -950,9 +919,9 @@ class NEZHA(BERT):
     """华为推出的NAZHA模型
     链接：https://arxiv.org/abs/1909.00204
     """
+
     def apply_embeddings(self, inputs):
-        """NEZHA的embedding是token、segment两者embedding之和
-        """
+        """NEZHA的embedding是token、segment两者embedding之和"""
         inputs = inputs[:]
         x = inputs.pop(0)
         if self.segment_vocab_size > 0:
@@ -966,24 +935,22 @@ class NEZHA(BERT):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         if self.segment_vocab_size > 0:
             if self.shared_segment_embeddings:
-                name = 'Embedding-Token'
+                name = "Embedding-Token"
             else:
-                name = 'Embedding-Segment'
+                name = "Embedding-Segment"
             s = self.apply(
                 inputs=s,
                 layer=Embedding,
                 input_dim=self.segment_vocab_size,
                 output_dim=self.embedding_size,
                 embeddings_initializer=self.initializer,
-                name=name
+                name=name,
             )
-            x = self.apply(
-                inputs=[x, s], layer=Add, name='Embedding-Token-Segment'
-            )
+            x = self.apply(inputs=[x, s], layer=Add, name="Embedding-Token-Segment")
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -991,13 +958,10 @@ class NEZHA(BERT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='Embedding-Norm'
+            name="Embedding-Norm",
         )
         x = self.apply(
-            inputs=x,
-            layer=Dropout,
-            rate=self.dropout_rate,
-            name='Embedding-Dropout'
+            inputs=x, layer=Dropout, rate=self.dropout_rate, name="Embedding-Dropout"
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -1005,7 +969,7 @@ class NEZHA(BERT):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Embedding-Mapping'
+                name="Embedding-Mapping",
             )
 
         return x
@@ -1017,16 +981,16 @@ class NEZHA(BERT):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Transformer-%d-FeedForward' % index
+        attention_name = "Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
         position_bias = self.compute_position_bias(x)
 
         # Self Attention
         xi, x = x, [x, x, x, position_bias]
-        arguments = {'a_bias': None, 'p_bias': 'typical_relative'}
+        arguments = {"a_bias": None, "p_bias": "typical_relative"}
         if attention_mask is not None:
-            arguments['a_bias'] = True
+            arguments["a_bias"] = True
             x.insert(3, attention_mask)
 
         x = self.apply(
@@ -1039,17 +1003,15 @@ class NEZHA(BERT):
             key_size=self.attention_key_size,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -1057,7 +1019,7 @@ class NEZHA(BERT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
 
         # Feed Forward
@@ -1068,17 +1030,15 @@ class NEZHA(BERT):
             units=self.intermediate_size,
             activation=self.hidden_act,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -1086,14 +1046,13 @@ class NEZHA(BERT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
 
         return x
 
     def compute_position_bias(self, inputs=None):
-        """经典相对位置编码
-        """
+        """经典相对位置编码"""
         if self.position_bias is None:
 
             x = inputs
@@ -1102,9 +1061,9 @@ class NEZHA(BERT):
                 layer=RelativePositionEmbedding,
                 input_dim=2 * 64 + 1,
                 output_dim=self.attention_key_size,
-                embeddings_initializer='Sinusoidal',
-                name='Embedding-Relative-Position',
-                trainable=False
+                embeddings_initializer="Sinusoidal",
+                name="Embedding-Relative-Position",
+                trainable=False,
             )
 
         return self.position_bias
@@ -1114,6 +1073,7 @@ class RoFormer(NEZHA):
     """旋转式位置编码的BERT模型
     链接：https://kexue.fm/archives/8265
     """
+
     def apply_main_layers(self, inputs, index):
         """RoFormer的主体是基于Self-Attention的模块
         顺序：Att --> Add --> LN --> FFN --> Add --> LN
@@ -1121,16 +1081,16 @@ class RoFormer(NEZHA):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Transformer-%d-FeedForward' % index
+        attention_name = "Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
         position_bias = self.compute_position_bias(x)
 
         # Self Attention
         xi, x = x, [x, x, x, position_bias]
-        arguments = {'a_bias': None, 'p_bias': 'rotary'}
+        arguments = {"a_bias": None, "p_bias": "rotary"}
         if attention_mask is not None:
-            arguments['a_bias'] = True
+            arguments["a_bias"] = True
             x.insert(3, attention_mask)
 
         x = self.apply(
@@ -1143,17 +1103,15 @@ class RoFormer(NEZHA):
             key_size=self.attention_key_size,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -1161,7 +1119,7 @@ class RoFormer(NEZHA):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
 
         # Feed Forward
@@ -1172,17 +1130,15 @@ class RoFormer(NEZHA):
             units=self.intermediate_size,
             activation=self.hidden_act,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -1190,14 +1146,13 @@ class RoFormer(NEZHA):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
 
         return x
 
     def compute_position_bias(self, inputs=None):
-        """Sinusoidal位置编码（直接返回）
-        """
+        """Sinusoidal位置编码（直接返回）"""
         if self.position_bias is None:
 
             if self.custom_position_ids:
@@ -1209,9 +1164,9 @@ class RoFormer(NEZHA):
                 inputs=x,
                 layer=SinusoidalPositionEmbedding,
                 output_dim=self.attention_key_size,
-                merge_mode='zero',
+                merge_mode="zero",
                 custom_position_ids=self.custom_position_ids,
-                name='Embedding-Rotary-Position'
+                name="Embedding-Rotary-Position",
             )
 
         return self.position_bias
@@ -1221,20 +1176,19 @@ class RoFormerV2(RoFormer):
     """RoFormerV2
     改动：去掉bias，简化Norm，优化初始化等。
     """
+
     def initializer(self, shape, dtype=None, order=2, gain=1.0):
-        """使用截断正态分布初始化
-        """
+        """使用截断正态分布初始化"""
         if shape[0] > 10000 or shape[0] < 10:
             hidden_size = shape[1]
         else:
             hidden_size = shape[0]
-        gain *= self.num_hidden_layers**(-1. / order)
+        gain *= self.num_hidden_layers ** (-1.0 / order)
         stddev = 1.13684723 / hidden_size**0.5 * gain
         return K.truncated_normal(shape, stddev=stddev)
 
     def apply_embeddings(self, inputs):
-        """RoFormerV2的embedding是token、segment两者embedding之和
-        """
+        """RoFormerV2的embedding是token、segment两者embedding之和"""
         inputs = inputs[:]
         x = inputs.pop(0)
         if self.segment_vocab_size > 0:
@@ -1247,29 +1201,24 @@ class RoFormerV2(RoFormer):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         if self.segment_vocab_size > 0:
             if self.shared_segment_embeddings:
-                name = 'Embedding-Token'
+                name = "Embedding-Token"
             else:
-                name = 'Embedding-Segment'
+                name = "Embedding-Segment"
             s = self.apply(
                 inputs=s,
                 layer=Embedding,
                 input_dim=self.segment_vocab_size,
                 output_dim=self.embedding_size,
                 embeddings_initializer=self.initializer,
-                name=name
+                name=name,
             )
-            x = self.apply(
-                inputs=[x, s], layer=Add, name='Embedding-Token-Segment'
-            )
+            x = self.apply(inputs=[x, s], layer=Add, name="Embedding-Token-Segment")
         x = self.apply(
-            inputs=x,
-            layer=Dropout,
-            rate=self.dropout_rate,
-            name='Embedding-Dropout'
+            inputs=x, layer=Dropout, rate=self.dropout_rate, name="Embedding-Dropout"
         )
         x = self.apply(
             inputs=x,
@@ -1277,7 +1226,7 @@ class RoFormerV2(RoFormer):
             zero_mean=False,
             scale=False,
             offset=False,
-            name='Embedding-Norm'
+            name="Embedding-Norm",
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -1286,7 +1235,7 @@ class RoFormerV2(RoFormer):
                 units=self.hidden_size,
                 use_bias=False,
                 kernel_initializer=self.initializer,
-                name='Embedding-Mapping'
+                name="Embedding-Mapping",
             )
 
         return x
@@ -1297,17 +1246,17 @@ class RoFormerV2(RoFormer):
         """
         x = inputs
 
-        attention_name = 'Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Transformer-%d-FeedForward' % index
+        attention_name = "Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
         position_bias = self.compute_position_bias(x)
 
         # Self Attention
         xi = x
         x = [x, x, x, position_bias]
-        arguments = {'a_bias': None, 'p_bias': 'rotary'}
+        arguments = {"a_bias": None, "p_bias": "rotary"}
         if attention_mask is not None:
-            arguments['a_bias'] = True
+            arguments["a_bias"] = True
             x.insert(3, attention_mask)
         x = self.apply(
             inputs=x,
@@ -1320,24 +1269,22 @@ class RoFormerV2(RoFormer):
             use_bias=False,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
         x = self.apply(
             inputs=x,
             layer=LayerNormalization,
             zero_mean=False,
             scale=False,
             offset=False,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
 
         # Feed Forward
@@ -1349,31 +1296,28 @@ class RoFormerV2(RoFormer):
             activation=self.hidden_act,
             use_bias=False,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         x = self.apply(
             inputs=x,
             layer=LayerNormalization,
             zero_mean=False,
             scale=False,
             offset=False,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
 
         return x
 
     def apply_final_layers(self, inputs):
-        """剩余部分
-        """
+        """剩余部分"""
         x = inputs
 
         if self.with_mlm:
@@ -1385,40 +1329,36 @@ class RoFormerV2(RoFormer):
                     units=self.embedding_size,
                     use_bias=False,
                     kernel_initializer=self.initializer,
-                    name='Output-Mapping'
+                    name="Output-Mapping",
                 )
             x = self.apply(
                 inputs=x,
                 layer=Dropout,
                 rate=self.dropout_rate,
-                name='Output-MLM-Dropout'
+                name="Output-MLM-Dropout",
             )
-            mlm_activation = 'softmax' if self.with_mlm is True else self.with_mlm
+            mlm_activation = "sparsemax" if self.with_mlm is True else self.with_mlm
             x = self.apply(
                 inputs=x,
                 layer=Embedding,
-                arguments={'mode': 'dense'},
-                name='Embedding-Token'
+                arguments={"mode": "dense"},
+                name="Embedding-Token",
             )
             x = self.apply(
                 inputs=x,
                 layer=Activation,
                 activation=mlm_activation,
-                name='Output-MLM-Activation'
+                name="Output-MLM-Activation",
             )
 
         return x
 
     def variable_mapping(self):
-        """删掉部分权重映射
-        """
+        """删掉部分权重映射"""
         mapping = super(RoFormerV2, self).variable_mapping()
 
         for k, v in mapping.items():
-            v = [
-                i for i in v
-                if not string_matching(i, ['beta', 'gamma', 'bias'])
-            ]
+            v = [i for i in v if not string_matching(i, ["beta", "gamma", "bias"])]
             mapping[k] = v
 
         return mapping
@@ -1428,13 +1368,10 @@ class ELECTRA(BERT):
     """Google推出的ELECTRA模型
     链接：https://arxiv.org/abs/2003.10555
     """
+
     @insert_arguments(with_discriminator=False)
-    @delete_arguments('with_pool', 'with_mlm')
-    def __init__(
-        self,
-        max_position,  # 序列最大长度
-        **kwargs  # 其余参数
-    ):
+    @delete_arguments("with_pool", "with_mlm")
+    def __init__(self, max_position, **kwargs):  # 序列最大长度  # 其余参数
         super(ELECTRA, self).__init__(max_position, **kwargs)
 
     def apply_final_layers(self, inputs):
@@ -1442,7 +1379,7 @@ class ELECTRA(BERT):
 
         if self.with_discriminator:
             if self.with_discriminator is True:
-                final_activation = 'sigmoid'
+                final_activation = "sigmoid"
             else:
                 final_activation = self.with_discriminator
             x = self.apply(
@@ -1451,7 +1388,7 @@ class ELECTRA(BERT):
                 units=self.hidden_size,
                 activation=self.hidden_act,
                 kernel_initializer=self.initializer,
-                name='Discriminator-Dense'
+                name="Discriminator-Dense",
             )
             x = self.apply(
                 inputs=x,
@@ -1459,37 +1396,35 @@ class ELECTRA(BERT):
                 units=1,
                 activation=final_activation,
                 kernel_initializer=self.initializer,
-                name='Discriminator-Prediction'
+                name="Discriminator-Prediction",
             )
 
         return x
 
     def load_variable(self, checkpoint, name):
-        """加载单个变量的函数
-        """
+        """加载单个变量的函数"""
         variable = super(ELECTRA, self).load_variable(checkpoint, name)
-        if name == 'electra/embeddings/word_embeddings':
+        if name == "electra/embeddings/word_embeddings":
             return self.load_embeddings(variable)
         else:
             return variable
 
     def variable_mapping(self):
         mapping = super(ELECTRA, self).variable_mapping()
-        mapping['Embedding-Mapping'] = [
-            'electra/embeddings_project/kernel',
-            'electra/embeddings_project/bias',
+        mapping["Embedding-Mapping"] = [
+            "electra/embeddings_project/kernel",
+            "electra/embeddings_project/bias",
         ]
         mapping = {
-            k: [i.replace('bert/', 'electra/') for i in v]
-            for k, v in mapping.items()
+            k: [i.replace("bert/", "electra/") for i in v] for k, v in mapping.items()
         }
-        mapping['Discriminator-Dense'] = [
-            'discriminator_predictions/dense/kernel',
-            'discriminator_predictions/dense/bias',
+        mapping["Discriminator-Dense"] = [
+            "discriminator_predictions/dense/kernel",
+            "discriminator_predictions/dense/bias",
         ]
-        mapping['Discriminator-Prediction'] = [
-            'discriminator_predictions/dense_1/kernel',
-            'discriminator_predictions/dense_1/bias',
+        mapping["Discriminator-Prediction"] = [
+            "discriminator_predictions/dense_1/kernel",
+            "discriminator_predictions/dense_1/bias",
         ]
         return mapping
 
@@ -1498,8 +1433,9 @@ class GPT(LM_Mask, BERT):
     """构建GPT模型
     链接：https://github.com/openai/finetune-transformer-lm
     """
-    @insert_arguments(final_activation='softmax')
-    @delete_arguments('with_pool', 'with_mlm')
+
+    @insert_arguments(final_activation="sparsemax")
+    @delete_arguments("with_pool", "with_mlm")
     def __init__(self, **kwargs):
         super(GPT, self).__init__(**kwargs)
 
@@ -1523,40 +1459,35 @@ class GPT(LM_Mask, BERT):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         if self.segment_vocab_size > 0:
             if self.shared_segment_embeddings:
-                name = 'Embedding-Token'
+                name = "Embedding-Token"
             else:
-                name = 'Embedding-Segment'
+                name = "Embedding-Segment"
             s = self.apply(
                 inputs=s,
                 layer=Embedding,
                 input_dim=self.segment_vocab_size,
                 output_dim=self.embedding_size,
                 embeddings_initializer=self.initializer,
-                name=name
+                name=name,
             )
-            x = self.apply(
-                inputs=[x, s], layer=Add, name='Embedding-Token-Segment'
-            )
+            x = self.apply(inputs=[x, s], layer=Add, name="Embedding-Token-Segment")
         x = self.apply(
             inputs=self.simplify([x, p]),
             layer=PositionEmbedding,
             input_dim=self.max_position,
             output_dim=self.embedding_size,
-            merge_mode='add',
+            merge_mode="add",
             hierarchical=self.hierarchical_position,
             embeddings_initializer=self.initializer,
             custom_position_ids=self.custom_position_ids,
-            name='Embedding-Position'
+            name="Embedding-Position",
         )
         x = self.apply(
-            inputs=x,
-            layer=Dropout,
-            rate=self.dropout_rate,
-            name='Embedding-Dropout'
+            inputs=x, layer=Dropout, rate=self.dropout_rate, name="Embedding-Dropout"
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -1564,50 +1495,44 @@ class GPT(LM_Mask, BERT):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Embedding-Mapping'
+                name="Embedding-Mapping",
             )
 
         return x
 
     def apply_final_layers(self, inputs):
-        """剩余部分
-        """
+        """剩余部分"""
         x = inputs
 
         # Language Model部分
         x = self.apply(
             inputs=x,
             layer=Embedding,
-            arguments={'mode': 'dense'},
-            name='Embedding-Token'
+            arguments={"mode": "dense"},
+            name="Embedding-Token",
         )
         x = self.apply(
             inputs=x,
             layer=Activation,
             activation=self.final_activation,
-            name='LM-Activation'
+            name="LM-Activation",
         )
 
         return x
 
     def load_variable(self, checkpoint, name):
-        """加载单个变量的函数
-        """
+        """加载单个变量的函数"""
         variable = super(GPT, self).load_variable(checkpoint, name)
-        if name == 'gpt/embeddings/word_embeddings':
+        if name == "gpt/embeddings/word_embeddings":
             return self.load_embeddings(variable)
         else:
             return variable
 
     def variable_mapping(self):
-        """映射到TF版GPT权重格式
-        """
+        """映射到TF版GPT权重格式"""
         mapping = super(GPT, self).variable_mapping()
         mapping = {
-            k: [
-                i.replace('bert/', 'gpt/').replace('encoder', 'transformer')
-                for i in v
-            ]
+            k: [i.replace("bert/", "gpt/").replace("encoder", "transformer") for i in v]
             for k, v in mapping.items()
         }
         return mapping
@@ -1617,17 +1542,16 @@ class GPT2(GPT):
     """构建GPT2模型
     链接: https://github.com/openai/gpt-2
     """
+
     def get_inputs(self):
-        """GPT2的输入是token_ids
-        """
+        """GPT2的输入是token_ids"""
         x_in = self.apply(
-            layer=Input, shape=(self.sequence_length,), name='Input-Token'
+            layer=Input, shape=(self.sequence_length,), name="Input-Token"
         )
         return x_in
 
     def apply_embeddings(self, inputs):
-        """GPT2的embedding是token、position两者embedding之和
-        """
+        """GPT2的embedding是token、position两者embedding之和"""
         x = inputs
 
         x = self.apply(
@@ -1637,17 +1561,17 @@ class GPT2(GPT):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         x = self.apply(
             inputs=x,
             layer=PositionEmbedding,
             input_dim=self.max_position,
             output_dim=self.embedding_size,
-            merge_mode='add',
+            merge_mode="add",
             hierarchical=self.hierarchical_position,
             embeddings_initializer=self.initializer,
-            name='Embedding-Position'
+            name="Embedding-Position",
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -1655,7 +1579,7 @@ class GPT2(GPT):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Embedding-Mapping'
+                name="Embedding-Mapping",
             )
 
         return x
@@ -1667,8 +1591,8 @@ class GPT2(GPT):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Transformer-%d-FeedForward' % index
+        attention_name = "Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
 
         # Self Attention
@@ -1681,29 +1605,27 @@ class GPT2(GPT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
         x = self.apply(
             inputs=[x, x, x, attention_mask],
             layer=MultiHeadAttention,
-            arguments={'a_bias': True},
+            arguments={"a_bias": True},
             heads=self.num_attention_heads,
             head_size=self.attention_head_size,
             out_dim=self.hidden_size,
             key_size=self.attention_key_size,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
 
         # Feed Forward
         xi = x
@@ -1715,7 +1637,7 @@ class GPT2(GPT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
         x = self.apply(
             inputs=x,
@@ -1723,22 +1645,19 @@ class GPT2(GPT):
             units=self.intermediate_size,
             activation=self.hidden_act,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         return x
 
     def apply_final_layers(self, inputs):
-        """剩余部分
-        """
+        """剩余部分"""
         x = inputs
         z = self.layer_norm_conds[0]
 
@@ -1750,29 +1669,25 @@ class GPT2(GPT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='Output-Norm'
+            name="Output-Norm",
         )
         x = self.apply(
-            inputs=x,
-            layer=Dropout,
-            rate=self.dropout_rate,
-            name='Output-Dropout'
+            inputs=x, layer=Dropout, rate=self.dropout_rate, name="Output-Dropout"
         )
         x = super(GPT2, self).apply_final_layers(x)
 
         return x
 
     def variable_mapping(self):
-        """映射到TF版GPT2权重格式
-        """
+        """映射到TF版GPT2权重格式"""
         mapping = super(GPT2, self).variable_mapping()
         mapping = {
-            k: [i.replace('output/LayerNorm', 'input/LayerNorm') for i in v]
+            k: [i.replace("output/LayerNorm", "input/LayerNorm") for i in v]
             for k, v in mapping.items()
         }
-        mapping['Output-Norm'] = [
-            'gpt/output/LayerNorm/beta',
-            'gpt/output/LayerNorm/gamma',
+        mapping["Output-Norm"] = [
+            "gpt/output/LayerNorm/beta",
+            "gpt/output/LayerNorm/gamma",
         ]
 
         return mapping
@@ -1784,17 +1699,16 @@ class GPT2_ML(GPT):
     注意：GPT2_ML虽然号称GPT2，但是它的结构其实更接近GPT，它自称GPT2的
          原因大概是因为它开源的版本参数量达到了GPT2的15亿参数。
     """
+
     def get_inputs(self):
-        """GPT2_ML的输入是token_ids
-        """
+        """GPT2_ML的输入是token_ids"""
         x_in = self.apply(
-            layer=Input, shape=(self.sequence_length,), name='Input-Token'
+            layer=Input, shape=(self.sequence_length,), name="Input-Token"
         )
         return x_in
 
     def apply_embeddings(self, inputs):
-        """GPT2_ML的embedding是token、position两者embedding之和
-        """
+        """GPT2_ML的embedding是token、position两者embedding之和"""
         x = inputs
         z = self.layer_norm_conds[0]
 
@@ -1805,17 +1719,17 @@ class GPT2_ML(GPT):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         x = self.apply(
             inputs=x,
             layer=PositionEmbedding,
             input_dim=self.max_position,
             output_dim=self.embedding_size,
-            merge_mode='add',
+            merge_mode="add",
             hierarchical=self.hierarchical_position,
             embeddings_initializer=self.initializer,
-            name='Embedding-Position'
+            name="Embedding-Position",
         )
         x = self.apply(
             inputs=self.simplify([x, z]),
@@ -1825,7 +1739,7 @@ class GPT2_ML(GPT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='Embedding-Norm'
+            name="Embedding-Norm",
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -1833,7 +1747,7 @@ class GPT2_ML(GPT):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Embedding-Mapping'
+                name="Embedding-Mapping",
             )
 
         return x
@@ -1845,12 +1759,12 @@ class GPT2_ML(GPT):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Transformer-%d-FeedForward' % index
+        attention_name = "Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
 
         # Self Attention
-        xi, x, arguments = x, [x, x, x, attention_mask], {'a_bias': True}
+        xi, x, arguments = x, [x, x, x, attention_mask], {"a_bias": True}
 
         x = self.apply(
             inputs=x,
@@ -1862,17 +1776,15 @@ class GPT2_ML(GPT):
             key_size=self.attention_key_size,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
 
         # Feed Forward
         xi = x
@@ -1884,7 +1796,7 @@ class GPT2_ML(GPT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm-0' % feed_forward_name
+            name="%s-Norm-0" % feed_forward_name,
         )
         x = self.apply(
             inputs=x,
@@ -1892,17 +1804,15 @@ class GPT2_ML(GPT):
             units=self.intermediate_size,
             activation=self.hidden_act,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
         x = self.apply(
             inputs=self.simplify([x, z]),
             layer=LayerNormalization,
@@ -1911,60 +1821,64 @@ class GPT2_ML(GPT):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm-1' % feed_forward_name
+            name="%s-Norm-1" % feed_forward_name,
         )
 
         return x
 
     def load_variable(self, checkpoint, name):
-        """加载单个变量的函数
-        """
+        """加载单个变量的函数"""
         variable = super(GPT2_ML, self).load_variable(checkpoint, name)
-        if name == 'newslm/embeddings/word_embed':
+        if name == "newslm/embeddings/word_embed":
             return self.load_embeddings(variable)
         else:
             return variable
 
     def variable_mapping(self):
-        """映射到官方GPT2_ML权重格式
-        """
+        """映射到官方GPT2_ML权重格式"""
         mapping = {
-            'Embedding-Token': ['newslm/embeddings/word_embed'],
-            'Embedding-Position': ['newslm/embeddings/pos_embed'],
-            'Embedding-Norm': [
-                'newslm/embeddings/LayerNorm_embed_norm/beta',
-                'newslm/embeddings/LayerNorm_embed_norm/gamma',
+            "Embedding-Token": ["newslm/embeddings/word_embed"],
+            "Embedding-Position": ["newslm/embeddings/pos_embed"],
+            "Embedding-Norm": [
+                "newslm/embeddings/LayerNorm_embed_norm/beta",
+                "newslm/embeddings/LayerNorm_embed_norm/gamma",
             ],
         }
 
         for i in range(self.num_hidden_layers):
-            prefix = 'newslm/layer%02d/' % i
-            mapping.update({
-                'Transformer-%d-MultiHeadSelfAttention' % i: [
-                    prefix + 'query_layer/kernel',
-                    prefix + 'query_layer/bias',
-                    prefix + 'key_layer/kernel',
-                    prefix + 'key_layer/bias',
-                    prefix + 'value_layer/kernel',
-                    prefix + 'value_layer/bias',
-                    prefix + 'context_projection_layer/kernel',
-                    prefix + 'context_projection_layer/bias',
-                ],
-                'Transformer-%d-FeedForward-Norm-0' % i: [
-                    prefix + 'LayerNorm_mlp_ln0/beta',
-                    prefix + 'LayerNorm_mlp_ln0/gamma',
-                ],
-                'Transformer-%d-FeedForward' % i: [
-                    prefix + 'intermediate/kernel',
-                    prefix + 'intermediate/bias',
-                    prefix + 'output/kernel',
-                    prefix + 'output/bias',
-                ],
-                'Transformer-%d-FeedForward-Norm-1' % i: [
-                    prefix + 'LayerNorm_mlp_ln1/beta',
-                    prefix + 'LayerNorm_mlp_ln1/gamma',
-                ],
-            })
+            prefix = "newslm/layer%02d/" % i
+            mapping.update(
+                {
+                    "Transformer-%d-MultiHeadSelfAttention"
+                    % i: [
+                        prefix + "query_layer/kernel",
+                        prefix + "query_layer/bias",
+                        prefix + "key_layer/kernel",
+                        prefix + "key_layer/bias",
+                        prefix + "value_layer/kernel",
+                        prefix + "value_layer/bias",
+                        prefix + "context_projection_layer/kernel",
+                        prefix + "context_projection_layer/bias",
+                    ],
+                    "Transformer-%d-FeedForward-Norm-0"
+                    % i: [
+                        prefix + "LayerNorm_mlp_ln0/beta",
+                        prefix + "LayerNorm_mlp_ln0/gamma",
+                    ],
+                    "Transformer-%d-FeedForward"
+                    % i: [
+                        prefix + "intermediate/kernel",
+                        prefix + "intermediate/bias",
+                        prefix + "output/kernel",
+                        prefix + "output/bias",
+                    ],
+                    "Transformer-%d-FeedForward-Norm-1"
+                    % i: [
+                        prefix + "LayerNorm_mlp_ln1/beta",
+                        prefix + "LayerNorm_mlp_ln1/gamma",
+                    ],
+                }
+            )
 
         return mapping
 
@@ -1978,113 +1892,125 @@ class T5_Base(Transformer):
     t5.1.1: https://github.com/google-research/text-to-text-transfer-transformer/blob/master/released_checkpoints.md#t511
     multilingual-t5: https://github.com/google-research/multilingual-t5
     """
-    @insert_arguments(version='t5.1.0')
+
+    @insert_arguments(version="t5.1.0")
     def __init__(self, **kwargs):
         super(T5_Base, self).__init__(**kwargs)
 
     def load_variable(self, checkpoint, name):
-        """加载单个变量的函数
-        """
+        """加载单个变量的函数"""
         variable = super(T5_Base, self).load_variable(checkpoint, name)
-        if name == 'shared/embedding':
+        if name == "shared/embedding":
             return self.load_embeddings(variable)
-        elif name == 'decoder/logits/kernel':
+        elif name == "decoder/logits/kernel":
             return self.load_embeddings(variable.T).T
-        elif 'relative_attention_bias' in name:
+        elif "relative_attention_bias" in name:
             return variable.T
         else:
             return variable
 
     def create_variable(self, name, value, dtype=None):
-        """在tensorflow中创建一个变量
-        """
-        if 'relative_attention_bias' in name:
+        """在tensorflow中创建一个变量"""
+        if "relative_attention_bias" in name:
             value = value.T
         return super(T5_Base, self).create_variable(name, value, dtype)
 
     def variable_mapping(self):
-        """映射到官方T5权重格式
-        """
+        """映射到官方T5权重格式"""
         mapping = {
-            'Embedding-Token': ['shared/embedding'],
-            'Encoder-Embedding-Relative-Position': [
-                'encoder/block_000/layer_000/SelfAttention/relative_attention_bias'
+            "Embedding-Token": ["shared/embedding"],
+            "Encoder-Embedding-Relative-Position": [
+                "encoder/block_000/layer_000/SelfAttention/relative_attention_bias"
             ],
-            'Encoder-Output-Norm': ['encoder/final_layer_norm/scale'],
-            'Decoder-Embedding-Relative-Position': [
-                'decoder/block_000/layer_000/SelfAttention/relative_attention_bias',
+            "Encoder-Output-Norm": ["encoder/final_layer_norm/scale"],
+            "Decoder-Embedding-Relative-Position": [
+                "decoder/block_000/layer_000/SelfAttention/relative_attention_bias",
             ],
-            'Decoder-Output-Norm': ['decoder/final_layer_norm/scale'],
+            "Decoder-Output-Norm": ["decoder/final_layer_norm/scale"],
         }
 
         for i in range(self.num_hidden_layers):
             # Encoder主体
-            prefix = 'encoder/block_%03d/' % i
-            mapping.update({
-                'Encoder-Transformer-%d-MultiHeadSelfAttention' % i: [
-                    prefix + 'layer_000/SelfAttention/q',
-                    prefix + 'layer_000/SelfAttention/k',
-                    prefix + 'layer_000/SelfAttention/v',
-                    prefix + 'layer_000/SelfAttention/o',
-                ],
-                'Encoder-Transformer-%d-MultiHeadSelfAttention-Norm' % i: [
-                    prefix + 'layer_000/layer_norm/scale',
-                ],
-                'Encoder-Transformer-%d-FeedForward' % i: [
-                    prefix + 'layer_001/DenseReluDense/wi/kernel',
-                    prefix + 'layer_001/DenseReluDense/wo/kernel',
-                ],
-                'Encoder-Transformer-%d-FeedForward-Norm' % i: [
-                    prefix + 'layer_001/layer_norm/scale',
-                ],
-            })
+            prefix = "encoder/block_%03d/" % i
+            mapping.update(
+                {
+                    "Encoder-Transformer-%d-MultiHeadSelfAttention"
+                    % i: [
+                        prefix + "layer_000/SelfAttention/q",
+                        prefix + "layer_000/SelfAttention/k",
+                        prefix + "layer_000/SelfAttention/v",
+                        prefix + "layer_000/SelfAttention/o",
+                    ],
+                    "Encoder-Transformer-%d-MultiHeadSelfAttention-Norm"
+                    % i: [
+                        prefix + "layer_000/layer_norm/scale",
+                    ],
+                    "Encoder-Transformer-%d-FeedForward"
+                    % i: [
+                        prefix + "layer_001/DenseReluDense/wi/kernel",
+                        prefix + "layer_001/DenseReluDense/wo/kernel",
+                    ],
+                    "Encoder-Transformer-%d-FeedForward-Norm"
+                    % i: [
+                        prefix + "layer_001/layer_norm/scale",
+                    ],
+                }
+            )
             # Decoder主体
-            prefix = 'decoder/block_%03d/' % i
-            mapping.update({
-                'Decoder-Transformer-%d-MultiHeadSelfAttention' % i: [
-                    prefix + 'layer_000/SelfAttention/q',
-                    prefix + 'layer_000/SelfAttention/k',
-                    prefix + 'layer_000/SelfAttention/v',
-                    prefix + 'layer_000/SelfAttention/o',
-                ],
-                'Decoder-Transformer-%d-MultiHeadSelfAttention-Norm' % i: [
-                    prefix + 'layer_000/layer_norm/scale',
-                ],
-                'Decoder-Transformer-%d-MultiHeadCrossAttention' % i: [
-                    prefix + 'layer_001/EncDecAttention/q',
-                    prefix + 'layer_001/EncDecAttention/k',
-                    prefix + 'layer_001/EncDecAttention/v',
-                    prefix + 'layer_001/EncDecAttention/o',
-                ],
-                'Decoder-Transformer-%d-MultiHeadCrossAttention-Norm' % i: [
-                    prefix + 'layer_001/layer_norm/scale',
-                ],
-                'Decoder-Transformer-%d-FeedForward' % i: [
-                    prefix + 'layer_002/DenseReluDense/wi/kernel',
-                    prefix + 'layer_002/DenseReluDense/wo/kernel',
-                ],
-                'Decoder-Transformer-%d-FeedForward-Norm' % i: [
-                    prefix + 'layer_002/layer_norm/scale',
-                ],
-            })
+            prefix = "decoder/block_%03d/" % i
+            mapping.update(
+                {
+                    "Decoder-Transformer-%d-MultiHeadSelfAttention"
+                    % i: [
+                        prefix + "layer_000/SelfAttention/q",
+                        prefix + "layer_000/SelfAttention/k",
+                        prefix + "layer_000/SelfAttention/v",
+                        prefix + "layer_000/SelfAttention/o",
+                    ],
+                    "Decoder-Transformer-%d-MultiHeadSelfAttention-Norm"
+                    % i: [
+                        prefix + "layer_000/layer_norm/scale",
+                    ],
+                    "Decoder-Transformer-%d-MultiHeadCrossAttention"
+                    % i: [
+                        prefix + "layer_001/EncDecAttention/q",
+                        prefix + "layer_001/EncDecAttention/k",
+                        prefix + "layer_001/EncDecAttention/v",
+                        prefix + "layer_001/EncDecAttention/o",
+                    ],
+                    "Decoder-Transformer-%d-MultiHeadCrossAttention-Norm"
+                    % i: [
+                        prefix + "layer_001/layer_norm/scale",
+                    ],
+                    "Decoder-Transformer-%d-FeedForward"
+                    % i: [
+                        prefix + "layer_002/DenseReluDense/wi/kernel",
+                        prefix + "layer_002/DenseReluDense/wo/kernel",
+                    ],
+                    "Decoder-Transformer-%d-FeedForward-Norm"
+                    % i: [
+                        prefix + "layer_002/layer_norm/scale",
+                    ],
+                }
+            )
 
-        if self.version.endswith('t5.1.1'):
-            mapping['Decoder-Output-LM'] = ['decoder/logits/kernel']
+        if self.version.endswith("t5.1.1"):
+            mapping["Decoder-Output-LM"] = ["decoder/logits/kernel"]
             for i in range(self.num_hidden_layers):
                 for layer in [
-                    'Encoder-Transformer-%d-FeedForward' % i,
-                    'Decoder-Transformer-%d-FeedForward' % i
+                    "Encoder-Transformer-%d-FeedForward" % i,
+                    "Decoder-Transformer-%d-FeedForward" % i,
                 ]:
                     mapping[layer] = [
-                        mapping[layer][0][:-7] + '_0' + mapping[layer][0][-7:],
-                        mapping[layer][0][:-7] + '_1' + mapping[layer][0][-7:],
-                        mapping[layer][1]
+                        mapping[layer][0][:-7] + "_0" + mapping[layer][0][-7:],
+                        mapping[layer][0][:-7] + "_1" + mapping[layer][0][-7:],
+                        mapping[layer][1],
                     ]
-            if self.version == 'mt5.1.1':
-                mapping['Encoder-Output-Norm'] = ['encoder/rms_norm/scale']
-                mapping['Decoder-Output-Norm'] = ['decoder/rms_norm/scale']
+            if self.version == "mt5.1.1":
+                mapping["Encoder-Output-Norm"] = ["encoder/rms_norm/scale"]
+                mapping["Decoder-Output-Norm"] = ["decoder/rms_norm/scale"]
                 mapping = {
-                    k: [i.replace('layer_norm', 'rms_norm') for i in v]
+                    k: [i.replace("layer_norm", "rms_norm") for i in v]
                     for k, v in mapping.items()
                 }
 
@@ -2092,15 +2018,12 @@ class T5_Base(Transformer):
 
 
 class T5_Encoder(T5_Base):
-    """Google的T5模型（Encoder）
-    """
+    """Google的T5模型（Encoder）"""
+
     def get_inputs(self):
-        """T5的Encoder的输入只有token_ids
-        """
+        """T5的Encoder的输入只有token_ids"""
         x_in = self.apply(
-            layer=Input,
-            shape=(self.sequence_length,),
-            name='Encoder-Input-Token'
+            layer=Input, shape=(self.sequence_length,), name="Encoder-Input-Token"
         )
         return x_in
 
@@ -2117,13 +2040,13 @@ class T5_Encoder(T5_Base):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='Encoder-Embedding-Dropout'
+            name="Encoder-Embedding-Dropout",
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -2131,7 +2054,7 @@ class T5_Encoder(T5_Base):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Encoder-Embedding-Mapping'
+                name="Encoder-Embedding-Mapping",
             )
 
         return x
@@ -2143,8 +2066,8 @@ class T5_Encoder(T5_Base):
         x = inputs
         z = self.layer_norm_conds[0]
 
-        attention_name = 'Encoder-Transformer-%d-MultiHeadSelfAttention' % index
-        feed_forward_name = 'Encoder-Transformer-%d-FeedForward' % index
+        attention_name = "Encoder-Transformer-%d-MultiHeadSelfAttention" % index
+        feed_forward_name = "Encoder-Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
         position_bias = self.compute_position_bias(x)
 
@@ -2160,12 +2083,12 @@ class T5_Encoder(T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % attention_name
+            name="%s-Norm" % attention_name,
         )
         x = self.apply(
             inputs=[x, x, x, position_bias],
             layer=MultiHeadAttention,
-            arguments={'p_bias': 't5_relative'},
+            arguments={"p_bias": "t5_relative"},
             heads=self.num_attention_heads,
             head_size=self.attention_head_size,
             out_dim=self.hidden_size,
@@ -2174,17 +2097,15 @@ class T5_Encoder(T5_Base):
             attention_scale=False,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=attention_name
+            name=attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % attention_name
+            name="%s-Dropout" % attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % attention_name)
 
         # Feed Forward
         xi = x
@@ -2198,7 +2119,7 @@ class T5_Encoder(T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
         x = self.apply(
             inputs=x,
@@ -2207,23 +2128,20 @@ class T5_Encoder(T5_Base):
             activation=self.hidden_act,
             use_bias=False,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
 
         return x
 
     def apply_final_layers(self, inputs):
-        """剩余部分
-        """
+        """剩余部分"""
         x = inputs
         z = self.layer_norm_conds[0]
 
@@ -2237,20 +2155,19 @@ class T5_Encoder(T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='Encoder-Output-Norm'
+            name="Encoder-Output-Norm",
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='Encoder-Output-Dropout'
+            name="Encoder-Output-Dropout",
         )
 
         return x
 
     def compute_position_bias(self, inputs=None):
-        """T5相对位置编码
-        """
+        """T5相对位置编码"""
         if self.position_bias is None:
 
             x = inputs
@@ -2261,7 +2178,7 @@ class T5_Encoder(T5_Base):
                 output_dim=self.num_attention_heads,
                 bidirectional=True,
                 embeddings_initializer=self.initializer,
-                name='Encoder-Embedding-Relative-Position'
+                name="Encoder-Embedding-Relative-Position",
             )
             self.position_bias = p
 
@@ -2269,25 +2186,22 @@ class T5_Encoder(T5_Base):
 
 
 class T5_Decoder(LM_Mask, T5_Base):
-    """Google的T5模型（Decoder）
-    """
+    """Google的T5模型（Decoder）"""
+
     def __init__(self, with_lm=True, cross_position_bias=True, **kwargs):
         super(T5_Decoder, self).__init__(**kwargs)
         self.with_lm = with_lm
         self.cross_position_bias = cross_position_bias
 
     def get_inputs(self):
-        """T5的Decoder的输入为context序列和token_ids
-        """
+        """T5的Decoder的输入为context序列和token_ids"""
         c_in = self.apply(
             layer=Input,
             shape=(self.sequence_length, self.hidden_size),
-            name='Input-Context'
+            name="Input-Context",
         )
         x_in = self.apply(
-            layer=Input,
-            shape=(self.sequence_length,),
-            name='Decoder-Input-Token'
+            layer=Input, shape=(self.sequence_length,), name="Decoder-Input-Token"
         )
         return [c_in, x_in]
 
@@ -2304,13 +2218,13 @@ class T5_Decoder(LM_Mask, T5_Base):
             output_dim=self.embedding_size,
             embeddings_initializer=self.initializer,
             mask_zero=True,
-            name='Embedding-Token'
+            name="Embedding-Token",
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='Decoder-Embedding-Dropout'
+            name="Decoder-Embedding-Dropout",
         )
         if self.embedding_size != self.hidden_size:
             x = self.apply(
@@ -2318,7 +2232,7 @@ class T5_Decoder(LM_Mask, T5_Base):
                 layer=Dense,
                 units=self.hidden_size,
                 kernel_initializer=self.initializer,
-                name='Decoder-Embedding-Mapping'
+                name="Decoder-Embedding-Mapping",
             )
 
         return [c, x]
@@ -2330,9 +2244,9 @@ class T5_Decoder(LM_Mask, T5_Base):
         c, x = inputs
         z = self.layer_norm_conds[0]
 
-        self_attention_name = 'Decoder-Transformer-%d-MultiHeadSelfAttention' % index
-        cross_attention_name = 'Decoder-Transformer-%d-MultiHeadCrossAttention' % index
-        feed_forward_name = 'Decoder-Transformer-%d-FeedForward' % index
+        self_attention_name = "Decoder-Transformer-%d-MultiHeadSelfAttention" % index
+        cross_attention_name = "Decoder-Transformer-%d-MultiHeadCrossAttention" % index
+        feed_forward_name = "Decoder-Transformer-%d-FeedForward" % index
         attention_mask = self.compute_attention_bias(index)
         position_bias = self.compute_position_bias([x, c])
 
@@ -2348,15 +2262,12 @@ class T5_Decoder(LM_Mask, T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % self_attention_name
+            name="%s-Norm" % self_attention_name,
         )
         x = self.apply(
             inputs=[x, x, x, attention_mask, position_bias[0]],
             layer=MultiHeadAttention,
-            arguments={
-                'a_bias': True,
-                'p_bias': 't5_relative'
-            },
+            arguments={"a_bias": True, "p_bias": "t5_relative"},
             heads=self.num_attention_heads,
             head_size=self.attention_head_size,
             out_dim=self.hidden_size,
@@ -2365,17 +2276,15 @@ class T5_Decoder(LM_Mask, T5_Base):
             attention_scale=False,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=self_attention_name
+            name=self_attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % self_attention_name
+            name="%s-Dropout" % self_attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % self_attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % self_attention_name)
 
         # Cross Attention
         xi = x
@@ -2389,14 +2298,14 @@ class T5_Decoder(LM_Mask, T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % cross_attention_name
+            name="%s-Norm" % cross_attention_name,
         )
         if self.cross_position_bias:
             inputs = [x, c, c, position_bias[1]]
-            arguments = {'a_bias': None, 'p_bias': 't5_relative'}
+            arguments = {"a_bias": None, "p_bias": "t5_relative"}
         else:
             inputs = [x, c, c]
-            arguments = {'a_bias': None, 'p_bias': None}
+            arguments = {"a_bias": None, "p_bias": None}
         x = self.apply(
             inputs=inputs,
             layer=MultiHeadAttention,
@@ -2409,17 +2318,15 @@ class T5_Decoder(LM_Mask, T5_Base):
             attention_scale=False,
             attention_dropout=self.attention_dropout_rate,
             kernel_initializer=self.initializer,
-            name=cross_attention_name
+            name=cross_attention_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % cross_attention_name
+            name="%s-Dropout" % cross_attention_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % cross_attention_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % cross_attention_name)
 
         # Feed Forward
         xi = x
@@ -2433,7 +2340,7 @@ class T5_Decoder(LM_Mask, T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='%s-Norm' % feed_forward_name
+            name="%s-Norm" % feed_forward_name,
         )
         x = self.apply(
             inputs=x,
@@ -2442,23 +2349,20 @@ class T5_Decoder(LM_Mask, T5_Base):
             activation=self.hidden_act,
             use_bias=False,
             kernel_initializer=self.initializer,
-            name=feed_forward_name
+            name=feed_forward_name,
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='%s-Dropout' % feed_forward_name
+            name="%s-Dropout" % feed_forward_name,
         )
-        x = self.apply(
-            inputs=[xi, x], layer=Add, name='%s-Add' % feed_forward_name
-        )
+        x = self.apply(inputs=[xi, x], layer=Add, name="%s-Add" % feed_forward_name)
 
         return [c, x]
 
     def apply_final_layers(self, inputs):
-        """剩余部分
-        """
+        """剩余部分"""
         c, x = inputs
         z = self.layer_norm_conds[0]
 
@@ -2472,20 +2376,20 @@ class T5_Decoder(LM_Mask, T5_Base):
             hidden_units=self.layer_norm_conds[1],
             hidden_activation=self.layer_norm_conds[2],
             hidden_initializer=self.initializer,
-            name='Decoder-Output-Norm'
+            name="Decoder-Output-Norm",
         )
         x = self.apply(
             inputs=x,
             layer=Dropout,
             rate=self.dropout_rate,
-            name='Decoder-Output-Dropout'
+            name="Decoder-Output-Dropout",
         )
         x = self.apply(
             inputs=x,
             layer=ScaleOffset,
-            scale=self.hidden_size**(-0.5),
+            scale=self.hidden_size ** (-0.5),
             offset=False,
-            name='Decoder-Output-Scale'
+            name="Decoder-Output-Scale",
         )
 
         if self.with_lm:
@@ -2496,21 +2400,21 @@ class T5_Decoder(LM_Mask, T5_Base):
                     layer=Dense,
                     units=self.embedding_size,
                     kernel_initializer=self.initializer,
-                    name='Decoder-Output-Mapping'
+                    name="Decoder-Output-Mapping",
                 )
-            lm_activation = 'softmax' if self.with_lm is True else self.with_lm
-            if self.version == 't5.1.0':
+            lm_activation = "sparsemax" if self.with_lm is True else self.with_lm
+            if self.version == "t5.1.0":
                 x = self.apply(
                     inputs=x,
                     layer=Embedding,
-                    arguments={'mode': 'dense'},
-                    name='Embedding-Token'
+                    arguments={"mode": "dense"},
+                    name="Embedding-Token",
                 )
                 x = self.apply(
                     inputs=x,
                     layer=Activation,
                     activation=lm_activation,
-                    name='Decoder-Output-LM-Activation'
+                    name="Decoder-Output-LM-Activation",
                 )
             else:
                 x = self.apply(
@@ -2520,14 +2424,13 @@ class T5_Decoder(LM_Mask, T5_Base):
                     activation=lm_activation,
                     use_bias=False,
                     kernel_initializer=self.initializer,
-                    name='Decoder-Output-LM'
+                    name="Decoder-Output-LM",
                 )
 
         return x
 
     def compute_attention_bias(self, inputs=None):
-        """修改LM Mask的序列长度（从 self.inputs[0] 改为 self.inputs[1] ）
-        """
+        """修改LM Mask的序列长度（从 self.inputs[0] 改为 self.inputs[1] ）"""
         old_inputs = self.inputs[:]
         self.inputs = [old_inputs[1]]
         mask = super(T5_Decoder, self).compute_attention_bias(inputs)
@@ -2535,8 +2438,7 @@ class T5_Decoder(LM_Mask, T5_Base):
         return mask
 
     def compute_position_bias(self, inputs=None):
-        """T5相对位置编码
-        """
+        """T5相对位置编码"""
         if self.position_bias is None:
 
             x, c = inputs
@@ -2547,7 +2449,7 @@ class T5_Decoder(LM_Mask, T5_Base):
                 output_dim=self.num_attention_heads,
                 bidirectional=False,
                 embeddings_initializer=self.initializer,
-                name='Decoder-Embedding-Relative-Position'
+                name="Decoder-Embedding-Relative-Position",
             )
             p2 = self.apply(
                 inputs=[x, c],
@@ -2556,7 +2458,7 @@ class T5_Decoder(LM_Mask, T5_Base):
                 output_dim=self.num_attention_heads,
                 bidirectional=False,
                 embeddings_initializer=self.initializer,
-                name='Decoder-Embedding-Relative-Position'
+                name="Decoder-Embedding-Relative-Position",
             )
             self.position_bias = (p1, p2)
 
@@ -2564,22 +2466,21 @@ class T5_Decoder(LM_Mask, T5_Base):
 
 
 class T5(T5_Base):
-    """Google的T5模型（Encoder-Decoder）
-    """
+    """Google的T5模型（Encoder-Decoder）"""
+
     def __init__(self, **kwargs):
         super(T5, self).__init__(**kwargs)
-        kwargs['layers'] = self.layers
-        e_name, d_name = 'Encoder', 'Decoder'
-        if 'name' in kwargs:
-            e_name = '%s_%s' % (kwargs['name'], e_name)
-            d_name = '%s_%s' % (kwargs['name'], d_name)
-            del kwargs['name']  # 防止重复传参
+        kwargs["layers"] = self.layers
+        e_name, d_name = "Encoder", "Decoder"
+        if "name" in kwargs:
+            e_name = "%s_%s" % (kwargs["name"], e_name)
+            d_name = "%s_%s" % (kwargs["name"], d_name)
+            del kwargs["name"]  # 防止重复传参
         self._encoder = T5_Encoder(name=e_name, **kwargs)
         self._decoder = T5_Decoder(name=d_name, **kwargs)
 
     def build(self, **kwargs):
-        """同时构建Encoder和Decoder
-        """
+        """同时构建Encoder和Decoder"""
         self._encoder.build(**kwargs)
         self._decoder.build(**kwargs)
         self._decoder.position_bias = None  # 下面call时将重新初始化
@@ -2593,11 +2494,11 @@ class T5(T5_Base):
 
 
 def extend_with_language_model(BaseModel):
-    """添加下三角的Attention Mask（语言模型用）
-    """
+    """添加下三角的Attention Mask（语言模型用）"""
+
     class LanguageModel(LM_Mask, BaseModel):
-        """带下三角Attention Mask的派生模型
-        """
+        """带下三角Attention Mask的派生模型"""
+
         def __init__(self, *args, **kwargs):
             super(LanguageModel, self).__init__(*args, **kwargs)
             self.with_mlm = self.with_mlm or True
@@ -2606,12 +2507,13 @@ def extend_with_language_model(BaseModel):
 
 
 def extend_with_unified_language_model(BaseModel):
-    """添加UniLM的Attention Mask（Seq2Seq模型用）
-    """
+    """添加UniLM的Attention Mask（Seq2Seq模型用）"""
+
     class UnifiedLanguageModel(UniLM_Mask, BaseModel):
         """带UniLM的Attention Mask的派生模型
         UniLM: https://arxiv.org/abs/1905.03197
         """
+
         def __init__(self, *args, **kwargs):
             super(UnifiedLanguageModel, self).__init__(*args, **kwargs)
             self.with_mlm = self.with_mlm or True
@@ -2628,7 +2530,7 @@ def data_parallel(model, devices=None, parts=None):
     if devices is None:
         devices = get_available_gpus()
     elif isinstance(devices, int):
-        devices = ['/device:GPU:%d' % i for i in range(devices)]
+        devices = ["/device:GPU:%d" % i for i in range(devices)]
 
     if parts is None:
         parts = len(devices)
@@ -2639,7 +2541,7 @@ def data_parallel(model, devices=None, parts=None):
     splited_outputs = [[] for _ in model.outputs]
     for i, device in enumerate(devices):
         with tf.device(device):
-            outputs = model(splited_inputs[i::len(devices)])
+            outputs = model(splited_inputs[i :: len(devices)])
             outputs = outputs if isinstance(outputs, list) else [outputs]
             for j, output in enumerate(outputs):
                 splited_outputs[j].append(output)
@@ -2652,74 +2554,70 @@ def data_parallel(model, devices=None, parts=None):
 def build_transformer_model(
     config_path=None,
     checkpoint_path=None,
-    model='bert',
-    application='encoder',
+    model="bert",
+    application="encoder",
     return_keras_model=True,
     **kwargs
 ):
-    """根据配置文件构建模型，可选加载checkpoint权重
-    """
+    """根据配置文件构建模型，可选加载checkpoint权重"""
     configs = {}
     if config_path is not None:
         configs.update(json.load(open(config_path)))
     configs.update(kwargs)
-    if 'max_position' not in configs:
-        configs['max_position'] = configs.get('max_position_embeddings', 512)
-    if 'dropout_rate' not in configs:
-        configs['dropout_rate'] = configs.get('hidden_dropout_prob')
-    if 'attention_dropout_rate' not in configs:
-        configs['attention_dropout_rate'] = configs.get(
-            'attention_probs_dropout_prob'
-        )
-    if 'segment_vocab_size' not in configs:
-        configs['segment_vocab_size'] = configs.get('type_vocab_size', 2)
+    if "max_position" not in configs:
+        configs["max_position"] = configs.get("max_position_embeddings", 512)
+    if "dropout_rate" not in configs:
+        configs["dropout_rate"] = configs.get("hidden_dropout_prob")
+    if "attention_dropout_rate" not in configs:
+        configs["attention_dropout_rate"] = configs.get("attention_probs_dropout_prob")
+    if "segment_vocab_size" not in configs:
+        configs["segment_vocab_size"] = configs.get("type_vocab_size", 2)
 
     models = {
-        'bert': BERT,
-        'albert': ALBERT,
-        'albert_unshared': ALBERT_Unshared,
-        'roberta': BERT,
-        'nezha': NEZHA,
-        'roformer': RoFormer,
-        'roformer_v2': RoFormerV2,
-        'electra': ELECTRA,
-        'gpt': GPT,
-        'gpt2': GPT2,
-        'gpt2_ml': GPT2_ML,
-        't5': T5,
-        't5_encoder': T5_Encoder,
-        't5_decoder': T5_Decoder,
-        't5.1.0': T5,
-        't5.1.0_encoder': T5_Encoder,
-        't5.1.0_decoder': T5_Decoder,
-        't5.1.1': T5,
-        't5.1.1_encoder': T5_Encoder,
-        't5.1.1_decoder': T5_Decoder,
-        'mt5.1.1': T5,
-        'mt5.1.1_encoder': T5_Encoder,
-        'mt5.1.1_decoder': T5_Decoder,
+        "bert": BERT,
+        "albert": ALBERT,
+        "albert_unshared": ALBERT_Unshared,
+        "roberta": BERT,
+        "nezha": NEZHA,
+        "roformer": RoFormer,
+        "roformer_v2": RoFormerV2,
+        "electra": ELECTRA,
+        "gpt": GPT,
+        "gpt2": GPT2,
+        "gpt2_ml": GPT2_ML,
+        "t5": T5,
+        "t5_encoder": T5_Encoder,
+        "t5_decoder": T5_Decoder,
+        "t5.1.0": T5,
+        "t5.1.0_encoder": T5_Encoder,
+        "t5.1.0_decoder": T5_Decoder,
+        "t5.1.1": T5,
+        "t5.1.1_encoder": T5_Encoder,
+        "t5.1.1_decoder": T5_Decoder,
+        "mt5.1.1": T5,
+        "mt5.1.1_encoder": T5_Encoder,
+        "mt5.1.1_decoder": T5_Decoder,
     }
 
     if is_string(model):
         model = model.lower()
         MODEL = models[model]
-        if model.startswith('t5.1.1'):
-            configs['version'] = 't5.1.1'
-        elif model.startswith('mt5.1.1'):
-            configs['version'] = 'mt5.1.1'
+        if model.startswith("t5.1.1"):
+            configs["version"] = "t5.1.1"
+        elif model.startswith("mt5.1.1"):
+            configs["version"] = "mt5.1.1"
     else:
         MODEL = model
 
     application = application.lower()
-    if application in ['lm', 'unilm'] and model in ['electra', 't5']:
+    if application in ["lm", "unilm"] and model in ["electra", "t5"]:
         raise ValueError(
-            '"%s" model can not be used as "%s" application.\n' %
-            (model, application)
+            '"%s" model can not be used as "%s" application.\n' % (model, application)
         )
 
-    if application == 'lm':
+    if application == "lm":
         MODEL = extend_with_language_model(MODEL)
-    elif application == 'unilm':
+    elif application == "unilm":
         MODEL = extend_with_unified_language_model(MODEL)
 
     transformer = MODEL(**configs)

--- a/bert4keras/models.py
+++ b/bert4keras/models.py
@@ -4,6 +4,7 @@
 import numpy as np
 from bert4keras.backend import get_available_gpus
 from bert4keras.layers import *
+from tensorflow_addons.activations import sparsemax
 from bert4keras.snippets import insert_arguments
 from bert4keras.snippets import delete_arguments
 from bert4keras.snippets import is_string, string_matching
@@ -1337,7 +1338,7 @@ class RoFormerV2(RoFormer):
                 rate=self.dropout_rate,
                 name="Output-MLM-Dropout",
             )
-            mlm_activation = "sparsemax" if self.with_mlm is True else self.with_mlm
+            mlm_activation = sparsemax if self.with_mlm is True else self.with_mlm
             x = self.apply(
                 inputs=x,
                 layer=Embedding,

--- a/examples/task_iflytek_adversarial_training.py
+++ b/examples/task_iflytek_adversarial_training.py
@@ -77,7 +77,7 @@ bert = build_transformer_model(
 
 output = Lambda(lambda x: x[:, 0])(bert.model.output)
 output = Dense(
-    units=num_classes, activation="sparsemax", kernel_initializer=bert.initializer
+    units=num_classes, activation="softmax", kernel_initializer=bert.initializer
 )(output)
 
 model = keras.models.Model(bert.model.input, output)

--- a/examples/task_iflytek_bert_of_theseus.py
+++ b/examples/task_iflytek_bert_of_theseus.py
@@ -20,9 +20,9 @@ maxlen = 128
 batch_size = 32
 
 # BERT base
-config_path = '/root/kg/bert/chinese_L-12_H-768_A-12/bert_config.json'
-checkpoint_path = '/root/kg/bert/chinese_L-12_H-768_A-12/bert_model.ckpt'
-dict_path = '/root/kg/bert/chinese_L-12_H-768_A-12/vocab.txt'
+config_path = "/root/kg/bert/chinese_L-12_H-768_A-12/bert_config.json"
+checkpoint_path = "/root/kg/bert/chinese_L-12_H-768_A-12/bert_model.ckpt"
+dict_path = "/root/kg/bert/chinese_L-12_H-768_A-12/vocab.txt"
 
 
 def load_data(filename):
@@ -33,26 +33,22 @@ def load_data(filename):
     with open(filename) as f:
         for i, l in enumerate(f):
             l = json.loads(l)
-            text, label = l['sentence'], l['label']
+            text, label = l["sentence"], l["label"]
             D.append((text, int(label)))
     return D
 
 
 # 加载数据集
-train_data = load_data(
-    '/root/CLUE-master/baselines/CLUEdataset/iflytek/train.json'
-)
-valid_data = load_data(
-    '/root/CLUE-master/baselines/CLUEdataset/iflytek/dev.json'
-)
+train_data = load_data("/root/CLUE-master/baselines/CLUEdataset/iflytek/train.json")
+valid_data = load_data("/root/CLUE-master/baselines/CLUEdataset/iflytek/dev.json")
 
 # 建立分词器
 tokenizer = Tokenizer(dict_path, do_lower_case=True)
 
 
 class data_generator(DataGenerator):
-    """数据生成器
-    """
+    """数据生成器"""
+
     def __iter__(self, random=False):
         batch_token_ids, batch_segment_ids, batch_labels = [], [], []
         for is_end, (text, label) in self.sample(random):
@@ -74,8 +70,8 @@ valid_generator = data_generator(valid_data, batch_size)
 
 
 class BinaryRandomChoice(Layer):
-    """随机二选一
-    """
+    """随机二选一"""
+
     def __init__(self, **kwargs):
         super(BinaryRandomChoice, self).__init__(**kwargs)
         self.supports_masking = True
@@ -95,8 +91,7 @@ class BinaryRandomChoice(Layer):
 
 
 def bert_of_theseus(predecessor, successor, classfier):
-    """bert of theseus
-    """
+    """bert of theseus"""
     inputs = predecessor.inputs
     # 固定住已经训练好的层
     for layer in predecessor.model.layers:
@@ -123,7 +118,7 @@ def bert_of_theseus(predecessor, successor, classfier):
 
 
 def evaluate(data, model):
-    total, right = 0., 0.
+    total, right = 0.0, 0.0
     for x_true, y_true in data:
         y_pred = model.predict(x_true).argmax(axis=1)
         y_true = y_true[:, 0]
@@ -133,10 +128,10 @@ def evaluate(data, model):
 
 
 class Evaluator(keras.callbacks.Callback):
-    """评估与保存
-    """
+    """评估与保存"""
+
     def __init__(self, savename):
-        self.best_val_acc = 0.
+        self.best_val_acc = 0.0
         self.savename = savename
 
     def on_epoch_end(self, epoch, logs=None):
@@ -144,10 +139,7 @@ class Evaluator(keras.callbacks.Callback):
         if val_acc > self.best_val_acc:
             self.best_val_acc = val_acc
             self.model.save_weights(self.savename)
-        print(
-            u'val_acc: %.5f, best_val_acc: %.5f\n' %
-            (val_acc, self.best_val_acc)
-        )
+        print("val_acc: %.5f, best_val_acc: %.5f\n" % (val_acc, self.best_val_acc))
 
 
 # 加载预训练模型（12层）
@@ -155,7 +147,7 @@ predecessor = build_transformer_model(
     config_path=config_path,
     checkpoint_path=checkpoint_path,
     return_keras_model=False,
-    prefix='Predecessor-'
+    prefix="Predecessor-",
 )
 
 # 加载预训练模型（3层）
@@ -164,65 +156,65 @@ successor = build_transformer_model(
     checkpoint_path=checkpoint_path,
     return_keras_model=False,
     num_hidden_layers=3,
-    prefix='Successor-'
+    prefix="Successor-",
 )
 
 # 判别模型
 x_in = Input(shape=K.int_shape(predecessor.output)[1:])
 x = Lambda(lambda x: x[:, 0])(x_in)
-x = Dense(units=num_classes, activation='softmax')(x)
+x = Dense(units=num_classes, activation="sparsemax")(x)
 classfier = Model(x_in, x)
 
 predecessor_model = Model(predecessor.inputs, classfier(predecessor.output))
 predecessor_model.compile(
-    loss='sparse_categorical_crossentropy',
+    loss="sparse_categorical_crossentropy",
     optimizer=Adam(2e-5),  # 用足够小的学习率
-    metrics=['sparse_categorical_accuracy'],
+    metrics=["sparse_categorical_accuracy"],
 )
 predecessor_model.summary()
 
 successor_model = Model(successor.inputs, classfier(successor.output))
 successor_model.compile(
-    loss='sparse_categorical_crossentropy',
+    loss="sparse_categorical_crossentropy",
     optimizer=Adam(2e-5),  # 用足够小的学习率
-    metrics=['sparse_categorical_accuracy'],
+    metrics=["sparse_categorical_accuracy"],
 )
 successor_model.summary()
 
 theseus_model = bert_of_theseus(predecessor, successor, classfier)
 theseus_model.compile(
-    loss='sparse_categorical_crossentropy',
+    loss="sparse_categorical_crossentropy",
     optimizer=Adam(2e-5),  # 用足够小的学习率
-    metrics=['sparse_categorical_accuracy'],
+    metrics=["sparse_categorical_accuracy"],
 )
 theseus_model.summary()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # 训练predecessor
-    predecessor_evaluator = Evaluator('best_predecessor.weights')
+    predecessor_evaluator = Evaluator("best_predecessor.weights")
     predecessor_model.fit(
         train_generator.forfit(),
         steps_per_epoch=len(train_generator),
         epochs=5,
-        callbacks=[predecessor_evaluator]
+        callbacks=[predecessor_evaluator],
     )
 
     # 训练theseus
-    theseus_evaluator = Evaluator('best_theseus.weights')
+    theseus_evaluator = Evaluator("best_theseus.weights")
     theseus_model.fit(
         train_generator.forfit(),
         steps_per_epoch=len(train_generator),
         epochs=10,
-        callbacks=[theseus_evaluator]
+        callbacks=[theseus_evaluator],
     )
-    theseus_model.load_weights('best_theseus.weights')
+    theseus_model.load_weights("best_theseus.weights")
 
     # 训练successor
-    successor_evaluator = Evaluator('best_successor.weights')
+    successor_evaluator = Evaluator("best_successor.weights")
     successor_model.fit(
         train_generator.forfit(),
         steps_per_epoch=len(train_generator),
         epochs=5,
-        callbacks=[successor_evaluator]
+        callbacks=[successor_evaluator],
     )

--- a/examples/task_iflytek_bert_of_theseus.py
+++ b/examples/task_iflytek_bert_of_theseus.py
@@ -162,7 +162,7 @@ successor = build_transformer_model(
 # 判别模型
 x_in = Input(shape=K.int_shape(predecessor.output)[1:])
 x = Lambda(lambda x: x[:, 0])(x_in)
-x = Dense(units=num_classes, activation="sparsemax")(x)
+x = Dense(units=num_classes, activation="softmax")(x)
 classfier = Model(x_in, x)
 
 predecessor_model = Model(predecessor.inputs, classfier(predecessor.output))

--- a/examples/task_iflytek_gradient_penalty.py
+++ b/examples/task_iflytek_gradient_penalty.py
@@ -20,9 +20,9 @@ maxlen = 128
 batch_size = 32
 
 # BERT base
-config_path = '/root/kg/bert/chinese_L-12_H-768_A-12/bert_config.json'
-checkpoint_path = '/root/kg/bert/chinese_L-12_H-768_A-12/bert_model.ckpt'
-dict_path = '/root/kg/bert/chinese_L-12_H-768_A-12/vocab.txt'
+config_path = "/root/kg/bert/chinese_L-12_H-768_A-12/bert_config.json"
+checkpoint_path = "/root/kg/bert/chinese_L-12_H-768_A-12/bert_model.ckpt"
+dict_path = "/root/kg/bert/chinese_L-12_H-768_A-12/vocab.txt"
 
 
 def load_data(filename):
@@ -33,26 +33,22 @@ def load_data(filename):
     with open(filename) as f:
         for i, l in enumerate(f):
             l = json.loads(l)
-            text, label = l['sentence'], l['label']
+            text, label = l["sentence"], l["label"]
             D.append((text, int(label)))
     return D
 
 
 # 加载数据集
-train_data = load_data(
-    '/root/CLUE-master/baselines/CLUEdataset/iflytek/train.json'
-)
-valid_data = load_data(
-    '/root/CLUE-master/baselines/CLUEdataset/iflytek/dev.json'
-)
+train_data = load_data("/root/CLUE-master/baselines/CLUEdataset/iflytek/train.json")
+valid_data = load_data("/root/CLUE-master/baselines/CLUEdataset/iflytek/dev.json")
 
 # 建立分词器
 tokenizer = Tokenizer(dict_path, do_lower_case=True)
 
 
 class data_generator(DataGenerator):
-    """数据生成器
-    """
+    """数据生成器"""
+
     def __iter__(self, random=False):
         batch_token_ids, batch_segment_ids, batch_labels = [], [], []
         for is_end, (text, label) in self.sample(random):
@@ -81,9 +77,7 @@ bert = build_transformer_model(
 
 output = Lambda(lambda x: x[:, 0])(bert.model.output)
 output = Dense(
-    units=num_classes,
-    activation='softmax',
-    kernel_initializer=bert.initializer
+    units=num_classes, activation="sparsemax", kernel_initializer=bert.initializer
 )(output)
 
 model = keras.models.Model(bert.model.input, output)
@@ -95,29 +89,28 @@ def sparse_categorical_crossentropy(y_true, y_pred):
     这主要是因为keras自带的sparse_categorical_crossentropy不支持求二阶梯度。
     """
     y_true = K.reshape(y_true, K.shape(y_pred)[:-1])
-    y_true = K.cast(y_true, 'int32')
+    y_true = K.cast(y_true, "int32")
     y_true = K.one_hot(y_true, K.shape(y_pred)[-1])
     return K.categorical_crossentropy(y_true, y_pred)
 
 
 def loss_with_gradient_penalty(y_true, y_pred, epsilon=1):
-    """带梯度惩罚的loss
-    """
+    """带梯度惩罚的loss"""
     loss = K.mean(sparse_categorical_crossentropy(y_true, y_pred))
-    embeddings = search_layer(y_pred, 'Embedding-Token').embeddings
-    gp = K.sum(K.gradients(loss, [embeddings])[0].values**2)
+    embeddings = search_layer(y_pred, "Embedding-Token").embeddings
+    gp = K.sum(K.gradients(loss, [embeddings])[0].values ** 2)
     return loss + 0.5 * epsilon * gp
 
 
 model.compile(
     loss=loss_with_gradient_penalty,
     optimizer=Adam(2e-5),
-    metrics=['sparse_categorical_accuracy'],
+    metrics=["sparse_categorical_accuracy"],
 )
 
 
 def evaluate(data):
-    total, right = 0., 0.
+    total, right = 0.0, 0.0
     for x_true, y_true in data:
         y_pred = model.predict(x_true).argmax(axis=1)
         y_true = y_true[:, 0]
@@ -127,39 +120,36 @@ def evaluate(data):
 
 
 class Evaluator(keras.callbacks.Callback):
-    """评估与保存
-    """
+    """评估与保存"""
+
     def __init__(self):
-        self.best_val_acc = 0.
+        self.best_val_acc = 0.0
 
     def on_epoch_end(self, epoch, logs=None):
         val_acc = evaluate(valid_generator)
         if val_acc > self.best_val_acc:
             self.best_val_acc = val_acc
-            model.save_weights('best_model.weights')
-        print(
-            u'val_acc: %.5f, best_val_acc: %.5f\n' %
-            (val_acc, self.best_val_acc)
-        )
+            model.save_weights("best_model.weights")
+        print("val_acc: %.5f, best_val_acc: %.5f\n" % (val_acc, self.best_val_acc))
 
 
 def predict_to_file(in_file, out_file):
     """输出预测结果到文件
     结果文件可以提交到 https://www.cluebenchmarks.com 评测。
     """
-    fw = open(out_file, 'w')
+    fw = open(out_file, "w")
     with open(in_file) as fr:
         for l in tqdm(fr):
             l = json.loads(l)
-            text = l['sentence']
+            text = l["sentence"]
             token_ids, segment_ids = tokenizer.encode(text, maxlen=maxlen)
             label = model.predict([[token_ids], [segment_ids]])[0].argmax()
-            l = json.dumps({'id': str(l['id']), 'label': str(label)})
-            fw.write(l + '\n')
+            l = json.dumps({"id": str(l["id"]), "label": str(label)})
+            fw.write(l + "\n")
     fw.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     evaluator = Evaluator()
 
@@ -167,10 +157,10 @@ if __name__ == '__main__':
         train_generator.forfit(),
         steps_per_epoch=len(train_generator),
         epochs=50,
-        callbacks=[evaluator]
+        callbacks=[evaluator],
     )
 
 else:
 
-    model.load_weights('best_model.weights')
+    model.load_weights("best_model.weights")
     # predict_to_file('/root/CLUE-master/baselines/CLUEdataset/iflytek/test.json', 'iflytek_predict.json')

--- a/examples/task_iflytek_multigpu.py
+++ b/examples/task_iflytek_multigpu.py
@@ -4,7 +4,7 @@
 
 import os
 
-os.environ['TF_KERAS'] = '1'  # 必须使用tf.keras
+os.environ["TF_KERAS"] = "1"  # 必须使用tf.keras
 
 import json
 import numpy as np
@@ -22,9 +22,9 @@ maxlen = 128
 batch_size = 32
 
 # BERT base
-config_path = '/root/kg/bert/chinese_L-12_H-768_A-12/bert_config.json'
-checkpoint_path = '/root/kg/bert/chinese_L-12_H-768_A-12/bert_model.ckpt'
-dict_path = '/root/kg/bert/chinese_L-12_H-768_A-12/vocab.txt'
+config_path = "/root/kg/bert/chinese_L-12_H-768_A-12/bert_config.json"
+checkpoint_path = "/root/kg/bert/chinese_L-12_H-768_A-12/bert_model.ckpt"
+dict_path = "/root/kg/bert/chinese_L-12_H-768_A-12/vocab.txt"
 
 
 def load_data(filename):
@@ -35,26 +35,22 @@ def load_data(filename):
     with open(filename) as f:
         for i, l in enumerate(f):
             l = json.loads(l)
-            text, label = l['sentence'], l['label']
+            text, label = l["sentence"], l["label"]
             D.append((text, int(label)))
     return D
 
 
 # 加载数据集
-train_data = load_data(
-    '/root/CLUE-master/baselines/CLUEdataset/iflytek/train.json'
-)
-valid_data = load_data(
-    '/root/CLUE-master/baselines/CLUEdataset/iflytek/dev.json'
-)
+train_data = load_data("/root/CLUE-master/baselines/CLUEdataset/iflytek/train.json")
+valid_data = load_data("/root/CLUE-master/baselines/CLUEdataset/iflytek/dev.json")
 
 # 建立分词器
 tokenizer = Tokenizer(dict_path, do_lower_case=True)
 
 
 class data_generator(DataGenerator):
-    """数据生成器
-    """
+    """数据生成器"""
+
     def __iter__(self, random=False):
         for is_end, (text, label) in self.sample(random):
             token_ids, segment_ids = tokenizer.encode(text, maxlen=maxlen)
@@ -80,71 +76,74 @@ with strategy.scope():  # 调用该策略
     output = Lambda(lambda x: x[:, 0])(bert.model.output)
     output = Dense(
         units=num_classes,
-        activation='softmax',
+        activation="sparsemax",
         kernel_initializer=bert.initializer,
-        name='Probas'
+        name="Probas",
     )(output)
 
     model = keras.models.Model(bert.model.input, output)
     model.compile(
-        loss='sparse_categorical_crossentropy',
+        loss="sparse_categorical_crossentropy",
         optimizer=Adam(2e-5),
-        metrics=['sparse_categorical_accuracy'],
+        metrics=["sparse_categorical_accuracy"],
     )
     model.summary()
     bert.load_weights_from_checkpoint(checkpoint_path)  # 必须最后才加载预训练权重
 
 
 class Evaluator(keras.callbacks.Callback):
-    """评估与保存
-    """
+    """评估与保存"""
+
     def __init__(self):
-        self.best_val_acc = 0.
+        self.best_val_acc = 0.0
 
     def on_epoch_end(self, epoch, logs=None):
-        val_acc = logs['sparse_categorical_accuracy']
+        val_acc = logs["sparse_categorical_accuracy"]
         if val_acc > self.best_val_acc:
             self.best_val_acc = val_acc
-            model.save_weights('best_model.weights')
-        print(
-            u'val_acc: %.5f, best_val_acc: %.5f\n' %
-            (val_acc, self.best_val_acc)
-        )
+            model.save_weights("best_model.weights")
+        print("val_acc: %.5f, best_val_acc: %.5f\n" % (val_acc, self.best_val_acc))
 
 
 def predict_to_file(in_file, out_file):
     """输出预测结果到文件
     结果文件可以提交到 https://www.cluebenchmarks.com 评测。
     """
-    fw = open(out_file, 'w')
+    fw = open(out_file, "w")
     with open(in_file) as fr:
         for l in tqdm(fr):
             l = json.loads(l)
-            text = l['sentence']
+            text = l["sentence"]
             token_ids, segment_ids = tokenizer.encode(text, maxlen=maxlen)
             token_ids, segment_ids = to_array([token_ids], [segment_ids])
             label = model.predict([token_ids, segment_ids])[0].argmax()
-            l = json.dumps({'id': str(l['id']), 'label': str(label)})
-            fw.write(l + '\n')
+            l = json.dumps({"id": str(l["id"]), "label": str(label)})
+            fw.write(l + "\n")
     fw.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     evaluator = Evaluator()
 
     train_dataset = train_generator.to_dataset(
-        types=[('float32', 'float32'), ('float32',)],
-        shapes=[([None], [None]), ([1],)],  # 配合后面的padded_batch=True，实现自动padding
-        names=[('Input-Token', 'Input-Segment'), ('Probas',)],
-        padded_batch=True
+        types=[("float32", "float32"), ("float32",)],
+        shapes=[
+            ([None], [None]),
+            ([1],),
+        ],  # 配合后面的padded_batch=True，实现自动padding
+        names=[("Input-Token", "Input-Segment"), ("Probas",)],
+        padded_batch=True,
     )  # 数据要转为tf.data.Dataset格式，names跟输入层/输出层的名字对应
 
     valid_dataset = valid_generator.to_dataset(
-        types=[('float32', 'float32'), ('float32',)],
-        shapes=[([None], [None]), ([1],)],  # 配合后面的padded_batch=True，实现自动padding
-        names=[('Input-Token', 'Input-Segment'), ('Probas',)],
-        padded_batch=True
+        types=[("float32", "float32"), ("float32",)],
+        shapes=[
+            ([None], [None]),
+            ([1],),
+        ],  # 配合后面的padded_batch=True，实现自动padding
+        names=[("Input-Token", "Input-Segment"), ("Probas",)],
+        padded_batch=True,
     )  # 数据要转为tf.data.Dataset格式，names跟输入层/输出层的名字对应
 
     model.fit(
@@ -153,10 +152,10 @@ if __name__ == '__main__':
         epochs=10,
         validation_data=valid_dataset,
         validation_steps=len(valid_generator),
-        callbacks=[evaluator]
+        callbacks=[evaluator],
     )
 
 else:
 
-    model.load_weights('best_model.weights')
+    model.load_weights("best_model.weights")
     # predict_to_file('/root/CLUE-master/baselines/CLUEdataset/iflytek/test.json', 'iflytek_predict.json')

--- a/examples/task_sentence_similarity_lcqmc.py
+++ b/examples/task_sentence_similarity_lcqmc.py
@@ -11,13 +11,13 @@ from bert4keras.snippets import sequence_padding, DataGenerator
 from bert4keras.snippets import open
 from keras.layers import Dropout, Dense
 
-set_gelu('tanh')  # 切换gelu版本
+set_gelu("tanh")  # 切换gelu版本
 
 maxlen = 128
 batch_size = 64
-config_path = '/root/kg/bert/chinese_wwm_L-12_H-768_A-12/bert_config.json'
-checkpoint_path = '/root/kg/bert/chinese_wwm_L-12_H-768_A-12/bert_model.ckpt'
-dict_path = '/root/kg/bert/chinese_wwm_L-12_H-768_A-12/vocab.txt'
+config_path = "/root/kg/bert/chinese_wwm_L-12_H-768_A-12/bert_config.json"
+checkpoint_path = "/root/kg/bert/chinese_wwm_L-12_H-768_A-12/bert_model.ckpt"
+dict_path = "/root/kg/bert/chinese_wwm_L-12_H-768_A-12/vocab.txt"
 
 
 def load_data(filename):
@@ -25,31 +25,29 @@ def load_data(filename):
     单条格式：(文本1, 文本2, 标签id)
     """
     D = []
-    with open(filename, encoding='utf-8') as f:
+    with open(filename, encoding="utf-8") as f:
         for l in f:
-            text1, text2, label = l.strip().split('\t')
+            text1, text2, label = l.strip().split("\t")
             D.append((text1, text2, int(label)))
     return D
 
 
 # 加载数据集
-train_data = load_data('datasets/lcqmc/lcqmc.train.data')
-valid_data = load_data('datasets/lcqmc/lcqmc.valid.data')
-test_data = load_data('datasets/lcqmc/lcqmc.test.data')
+train_data = load_data("datasets/lcqmc/lcqmc.train.data")
+valid_data = load_data("datasets/lcqmc/lcqmc.valid.data")
+test_data = load_data("datasets/lcqmc/lcqmc.test.data")
 
 # 建立分词器
 tokenizer = Tokenizer(dict_path, do_lower_case=True)
 
 
 class data_generator(DataGenerator):
-    """数据生成器
-    """
+    """数据生成器"""
+
     def __iter__(self, random=False):
         batch_token_ids, batch_segment_ids, batch_labels = [], [], []
         for is_end, (text1, text2, label) in self.sample(random):
-            token_ids, segment_ids = tokenizer.encode(
-                text1, text2, maxlen=maxlen
-            )
+            token_ids, segment_ids = tokenizer.encode(text1, text2, maxlen=maxlen)
             batch_token_ids.append(token_ids)
             batch_segment_ids.append(segment_ids)
             batch_labels.append([label])
@@ -70,18 +68,18 @@ bert = build_transformer_model(
 )
 
 output = Dropout(rate=0.1)(bert.model.output)
-output = Dense(
-    units=2, activation='softmax', kernel_initializer=bert.initializer
-)(output)
+output = Dense(units=2, activation="sparsemax", kernel_initializer=bert.initializer)(
+    output
+)
 
 model = keras.models.Model(bert.model.input, output)
 model.summary()
 
 model.compile(
-    loss='sparse_categorical_crossentropy',
+    loss="sparse_categorical_crossentropy",
     optimizer=Adam(2e-5),  # 用足够小的学习率
     # optimizer=PiecewiseLinearLearningRate(Adam(5e-5), {10000: 1, 30000: 0.1}),
-    metrics=['accuracy'],
+    metrics=["accuracy"],
 )
 
 # 转换数据集
@@ -91,7 +89,7 @@ test_generator = data_generator(test_data, batch_size)
 
 
 def evaluate(data):
-    total, right = 0., 0.
+    total, right = 0.0, 0.0
     for x_true, y_true in data:
         y_pred = model.predict(x_true).argmax(axis=1)
         y_true = y_true[:, 0]
@@ -101,24 +99,24 @@ def evaluate(data):
 
 
 class Evaluator(keras.callbacks.Callback):
-    """评估与保存
-    """
+    """评估与保存"""
+
     def __init__(self):
-        self.best_val_acc = 0.
+        self.best_val_acc = 0.0
 
     def on_epoch_end(self, epoch, logs=None):
         val_acc = evaluate(valid_generator)
         if val_acc > self.best_val_acc:
             self.best_val_acc = val_acc
-            model.save_weights('best_model.weights')
+            model.save_weights("best_model.weights")
         test_acc = evaluate(test_generator)
         print(
-            u'val_acc: %.5f, best_val_acc: %.5f, test_acc: %.5f\n' %
-            (val_acc, self.best_val_acc, test_acc)
+            "val_acc: %.5f, best_val_acc: %.5f, test_acc: %.5f\n"
+            % (val_acc, self.best_val_acc, test_acc)
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     evaluator = Evaluator()
 
@@ -126,12 +124,12 @@ if __name__ == '__main__':
         train_generator.forfit(),
         steps_per_epoch=len(train_generator),
         epochs=20,
-        callbacks=[evaluator]
+        callbacks=[evaluator],
     )
 
-    model.load_weights('best_model.weights')
-    print(u'final test acc: %05f\n' % (evaluate(test_generator)))
+    model.load_weights("best_model.weights")
+    print("final test acc: %05f\n" % (evaluate(test_generator)))
 
 else:
 
-    model.load_weights('best_model.weights')
+    model.load_weights("best_model.weights")


### PR DESCRIPTION
## Summary
Implemented sparsemax and replaced all softmax activations with sparsemax. Sparsemax is known for producing sparse probability distributions (some outputs exactly zero), possibly decreasing runtime in certain transformer architectures.

## Testing
Unit testing with various input logits works as expected.
```Python
# unit test
def test_sparsemax():
    # test input tensor
    logits = np.array([[ 1.0750,  0.4262, -0.6458, -0.1671,  0.8370],
        [ 2.0811,  1.6589,  1.8492, -0.6689,  2.0189],
        [ 0.1256, -0.4551,  0.1884,  1.9810,  0.1333]])
    # expected behavior
    output = sparsemax(logits, axis=-1).numpy()
    print("Input logits:")
    print(logits)
    print("Sparsemax output:")
    print(output)
```

## Next steps
- [ ] Integration testing